### PR TITLE
fix: remove scroll jump from showSessionIndicator

### DIFF
--- a/static/js/ai-budtender-chat.js
+++ b/static/js/ai-budtender-chat.js
@@ -1368,9 +1368,8 @@ class AIBudtenderChat {
         const indicator = document.createElement('div');
         indicator.className = `session-indicator ${type}`;
         indicator.textContent = message;
-        
+
         this.elements.messages.appendChild(indicator);
-        this.scrollToBottom();
         
         // Auto-remove after 5 seconds
         setTimeout(() => {


### PR DESCRIPTION
scrollToBottom() in showSessionIndicator() was the root cause of the viewport jumping to the bottom after streaming completed:
  _finalizeStreamingBubble → handleContextAwareResponse
  → showSessionIndicator("Sesión restaurada") → scrollToBottom()

The indicator appends after strain cards and forced scroll past them, hiding the streamed text the user was reading.