### PR TITLE
fix: fix mixed-language content on English terpene/article pages

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -386,6 +386,12 @@ msgstr ""
 "you personalized strain recommendations. Browse strains, explore terpene "
 "profiles, and find dispensaries near you."
 
+msgid "Terpeno"
+msgstr "Terpene"
+
+msgid "Descripción y propiedades del terpeno %(name)s"
+msgstr "Description and properties of terpene %(name)s"
+
 msgid "Superuser must have is_staff=True."
 msgstr "Superuser must have is_staff=True."
 

--- a/templates/terpene_detail.html
+++ b/templates/terpene_detail.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 {% block title %}
-    Descripción y propiedades del terpeno {{ terpene.title }}
+    {% blocktrans with name=terpene.title %}Descripción y propiedades del terpeno {{ name }}{% endblocktrans %}
 {% endblock %}
 
 {% block keywords %}
@@ -17,7 +18,7 @@
             <div class="container">
                 <div class="article-page__header">
                     <div class="article-page__case">
-                        <a href="#" class="category-tag">Terpeno</a>
+                        <a href="#" class="category-tag">{% trans "Terpeno" %}</a>
                     </div>
                     <h1 class="article-page__title">{{ terpene.title }}</h1>
                     <div class="article__footer">


### PR DESCRIPTION
- terpene_detail.html: replace hardcoded Spanish title prefix and breadcrumb with translatable {% trans %} / {% blocktrans %} tags
- views.py: extract TOC headings dynamically from current language's text_content instead of stored h3_headings (which was generated from Spanish content), fixing the Spanish sidebar on EN pages
- locale/en: add translations for "Terpeno" → "Terpene" and the terpene page title prefix

Pages like /en/terpenes/cariofileno/ previously had Spanish <title>, Spanish breadcrumb, and Spanish table of contents despite English body content — causing Google to treat them as low-quality mixed-language pages and skip indexing them.