### PR TITLE
Fix chat session persistence and add resume FAB after V2 migration

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -588,6 +588,10 @@ msgstr "Contents"
 msgid "Resultado de la búsqueda"
 msgstr "Search results"
 
+#: templates/base_v2.html
+msgid "Continuar chat"
+msgstr "Resume chat"
+
 #~ msgid "Efectos"
 #~ msgstr "Effects"
 

--- a/static/css/styles_v2.css
+++ b/static/css/styles_v2.css
@@ -1361,6 +1361,83 @@ select:focus-visible,
 }
 
 
+/* Chat Resume FAB (floating action button) */
+.chat-resume-fab {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 10000;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--bg-card);
+  border: 2px solid var(--accent-green);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(0.8);
+  transition: opacity 0.3s var(--ease-out),
+              visibility 0s 0.3s,
+              transform 0.3s var(--ease-out),
+              box-shadow 0.2s;
+  box-shadow: 0 4px 20px rgba(0, 230, 118, 0.15);
+}
+
+.chat-resume-fab--visible {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1);
+  transition: opacity 0.3s var(--ease-out),
+              visibility 0s 0s,
+              transform 0.3s var(--ease-out),
+              box-shadow 0.2s;
+}
+
+.chat-resume-fab:hover {
+  transform: scale(1.08);
+  box-shadow: 0 6px 28px rgba(0, 230, 118, 0.3);
+}
+
+.chat-resume-fab:active {
+  transform: scale(0.95);
+}
+
+.chat-resume-fab__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.chat-resume-fab__pulse {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  border: 2px solid var(--bg-primary);
+}
+
+.chat-resume-fab__pulse::after {
+  content: '';
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  opacity: 0.4;
+  animation: chatFabPulse 2s ease-in-out infinite;
+}
+
+@keyframes chatFabPulse {
+  0%, 100% { transform: scale(1); opacity: 0.4; }
+  50% { transform: scale(1.6); opacity: 0; }
+}
+
 /* --------------------------------------------------------------------------
    14. Responsive — Tablet (max-width: 1024px)
    -------------------------------------------------------------------------- */
@@ -1399,6 +1476,18 @@ select:focus-visible,
   :root {
     --section-pad-x: 16px;
     --section-pad-y: 48px;
+  }
+
+  .chat-resume-fab {
+    bottom: 16px;
+    right: 16px;
+    width: 52px;
+    height: 52px;
+  }
+
+  .chat-resume-fab__avatar {
+    width: 32px;
+    height: 32px;
   }
 
   /* Header: show hamburger, hide desktop nav */

--- a/static/js/chat-fullscreen.js
+++ b/static/js/chat-fullscreen.js
@@ -2,7 +2,8 @@
  * Fullscreen Chat for AI Budtender.
  *
  * Requires window.ChatFullscreenConfig with translated error strings:
- *   { errRateLimit, errUnavailable, errServer, errConnection, errNoInternet }
+ *   { errRateLimit, errUnavailable, errServer, errConnection, errNoInternet,
+ *     resumeChat }
  */
 (function() {
     var cfg = window.ChatFullscreenConfig || {};
@@ -12,15 +13,30 @@
     var fsInput    = document.getElementById('chat-fullscreen-input');
     var fsSend     = document.getElementById('chat-fullscreen-send');
     var fsClose    = document.getElementById('chat-fullscreen-close');
+    var resumeFab  = document.getElementById('chat-resume-fab');
 
     if (!fullscreen) return; // chat not enabled on this page
+
+    // --- Session persistence constants -------------------------------------------
+
+    var STORAGE_KEY_HISTORY  = 'ai-budtender-chat-history';
+    var STORAGE_KEY_TIMESTAMP = 'ai-budtender-chat-ts';
+    var SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
 
     // --- Open / Close -----------------------------------------------------------
 
     var previouslyFocused = null;
+    var historyRestored = false;
 
     function openFullscreenChat(prefillText) {
         previouslyFocused = document.activeElement;
+
+        // Restore chat history on first open if not already done
+        if (!historyRestored) {
+            restoreChatHistory();
+            historyRestored = true;
+        }
+
         fullscreen.classList.add('chat-fullscreen--active');
         fullscreen.setAttribute('aria-hidden', 'false');
         document.body.style.overflow = 'hidden';
@@ -30,6 +46,13 @@
         } else if (fsInput) {
             fsInput.focus();
         }
+
+        // Scroll to bottom after restore
+        if (fsMessages) {
+            fsMessages.scrollTop = fsMessages.scrollHeight;
+        }
+
+        updateResumeFab();
     }
 
     function closeFullscreenChat() {
@@ -39,6 +62,7 @@
         if (previouslyFocused && previouslyFocused.focus) {
             previouslyFocused.focus();
         }
+        updateResumeFab();
     }
 
     if (fsClose) {
@@ -92,6 +116,110 @@
         return div.innerHTML;
     }
 
+    // --- Chat history persistence ------------------------------------------------
+
+    function isSessionExpired() {
+        var ts = localStorage.getItem(STORAGE_KEY_TIMESTAMP);
+        if (!ts) return true;
+        return (Date.now() - parseInt(ts, 10)) > SESSION_TTL_MS;
+    }
+
+    function touchSessionTimestamp() {
+        localStorage.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
+    }
+
+    function getChatHistory() {
+        if (isSessionExpired()) {
+            clearChatSession();
+            return [];
+        }
+        try {
+            var raw = localStorage.getItem(STORAGE_KEY_HISTORY);
+            return raw ? JSON.parse(raw) : [];
+        } catch(e) {
+            return [];
+        }
+    }
+
+    function saveChatHistory(history) {
+        try {
+            // Keep max 50 messages to avoid localStorage bloat
+            var trimmed = history.slice(-50);
+            localStorage.setItem(STORAGE_KEY_HISTORY, JSON.stringify(trimmed));
+            touchSessionTimestamp();
+        } catch(e) {
+            // localStorage full — silently fail
+        }
+    }
+
+    function appendToHistory(entry) {
+        var history = getChatHistory();
+        history.push(entry);
+        saveChatHistory(history);
+    }
+
+    function clearChatSession() {
+        localStorage.removeItem(STORAGE_KEY_HISTORY);
+        localStorage.removeItem(STORAGE_KEY_TIMESTAMP);
+        localStorage.removeItem('ai-budtender-session-id');
+        localStorage.removeItem('ai_budtender_session_id');
+    }
+
+    function hasActiveSession() {
+        if (isSessionExpired()) {
+            clearChatSession();
+            return false;
+        }
+        var history = getChatHistory();
+        return history.length > 0;
+    }
+
+    function restoreChatHistory() {
+        var history = getChatHistory();
+        if (!history.length) return;
+
+        // Hide welcome message
+        var welcome = fsMessages.querySelector('.chat-fullscreen__welcome');
+        if (welcome) welcome.style.display = 'none';
+
+        for (var i = 0; i < history.length; i++) {
+            var entry = history[i];
+            if (entry.role === 'user') {
+                addMessageToFullscreen('user', entry.text, true);
+            } else if (entry.role === 'assistant') {
+                var msg = addMessageToFullscreen('assistant', '', true);
+                var textEl = msg.querySelector('.chat-fullscreen__msg-text');
+                if (textEl) {
+                    textEl.innerHTML = parseSimpleMarkdown(entry.text);
+                }
+                if (entry.strains && entry.strains.length) {
+                    renderStrainCards(msg, entry.strains);
+                }
+            }
+        }
+    }
+
+    // --- Resume FAB --------------------------------------------------------------
+
+    function updateResumeFab() {
+        if (!resumeFab) return;
+        var chatOpen = fullscreen.classList.contains('chat-fullscreen--active');
+        if (!chatOpen && hasActiveSession()) {
+            resumeFab.classList.add('chat-resume-fab--visible');
+        } else {
+            resumeFab.classList.remove('chat-resume-fab--visible');
+        }
+    }
+
+    if (resumeFab) {
+        resumeFab.addEventListener('click', function() {
+            openFullscreenChat('');
+        });
+    }
+
+    // Check on page load
+    updateResumeFab();
+
     // --- UI builders -------------------------------------------------------------
 
     function showTypingIndicator() {
@@ -110,7 +238,7 @@
         return typing;
     }
 
-    function addMessageToFullscreen(role, text) {
+    function addMessageToFullscreen(role, text, skipPersist) {
         var welcome = fsMessages.querySelector('.chat-fullscreen__welcome');
         if (welcome) welcome.style.display = 'none';
 
@@ -119,6 +247,12 @@
         msg.innerHTML = '<div class="chat-fullscreen__msg-text">' + escapeHtml(text) + '</div>';
         fsMessages.appendChild(msg);
         fsMessages.scrollTop = fsMessages.scrollHeight;
+
+        // Persist user messages immediately
+        if (!skipPersist && role === 'user') {
+            appendToHistory({ role: 'user', text: text });
+        }
+
         return msg;
     }
 
@@ -264,6 +398,15 @@
         }
     }
 
+    function persistAssistantMessage(text, strains) {
+        appendToHistory({
+            role: 'assistant',
+            text: text,
+            strains: strains || []
+        });
+        updateResumeFab();
+    }
+
     function sendFullscreenMessage() {
         if (fsIsSending) return;
         if (!fsInput || !fsInput.value.trim()) return;
@@ -313,9 +456,11 @@
                 if (data.response) {
                     var fbMsg = addMessageToFullscreen('assistant', data.response);
                     if (data.session_id) setSessionId(data.session_id);
-                    if (data.recommended_strains && data.recommended_strains.length) {
-                        renderStrainCards(fbMsg, data.recommended_strains);
+                    var fbStrains = data.recommended_strains || [];
+                    if (fbStrains.length) {
+                        renderStrainCards(fbMsg, fbStrains);
                     }
+                    persistAssistantMessage(data.response, fbStrains);
                 } else if (data.error) {
                     addErrorMessage(data.error);
                 } else {
@@ -360,6 +505,7 @@
             var textSpan = null;
             var fullText = '';
             var metadataResponse = '';
+            var streamStrains = null;
             var finalized = false;
 
             function finalize() {
@@ -378,6 +524,7 @@
                     addErrorMessage(cfg.errServer || 'Server error');
                 } else {
                     finalizeStreamingBubble(streamBubble);
+                    persistAssistantMessage(fullText, streamStrains);
                 }
                 unlockSend();
             }
@@ -397,6 +544,7 @@
                             var strains = null;
                             if (data.data && data.data.recommended_strains) strains = data.data.recommended_strains;
                             if (data.recommended_strains) strains = data.recommended_strains;
+                            streamStrains = strains;
 
                             // Capture response text from metadata (non-search branches send it here)
                             if (data.data && data.data.response) metadataResponse = data.data.response;
@@ -483,5 +631,10 @@
             this.style.height = 'auto';
             this.style.height = Math.min(this.scrollHeight, 120) + 'px';
         });
+    }
+
+    // --- Expired session cleanup on load -----------------------------------------
+    if (isSessionExpired()) {
+        clearChatSession();
     }
 })();

--- a/templates/base_v2.html
+++ b/templates/base_v2.html
@@ -190,6 +190,14 @@
 </footer>
 {% endblock footer %}
 
+<!-- Chat Resume FAB (floating action button) -->
+{% if ENABLE_AI_CHAT %}
+<button class="chat-resume-fab" id="chat-resume-fab" aria-label="{% trans 'Continuar chat' %}">
+    <img src="{% static 'img/mascot_avatar_60x60.png' %}" alt="" class="chat-resume-fab__avatar">
+    <span class="chat-resume-fab__pulse"></span>
+</button>
+{% endif %}
+
 <!-- Fullscreen Chat Overlay -->
 {% if ENABLE_AI_CHAT %}
 <div class="chat-fullscreen" id="chat-fullscreen" role="dialog" aria-label="AI Budtender Chat" aria-hidden="true">
@@ -245,7 +253,8 @@
             errUnavailable: '{% trans "El servicio no está disponible en este momento. Inténtalo más tarde." %}',
             errServer: '{% trans "Error del servidor. Por favor, inténtalo de nuevo." %}',
             errConnection: '{% trans "Error de conexión. Inténtalo de nuevo." %}',
-            errNoInternet: '{% trans "No se puede conectar con el servidor. Verifica tu conexión a internet." %}'
+            errNoInternet: '{% trans "No se puede conectar con el servidor. Verifica tu conexión a internet." %}',
+            resumeChat: '{% trans "Continuar chat" %}'
         };
     </script>
     <script src="{% static 'js/chat-fullscreen.js' %}"></script>


### PR DESCRIPTION
Restore localStorage-based chat history with 1-hour TTL so users can resume conversations across page navigations. Add a floating action button (FAB) that pulses when an active session exists, allowing users to reopen the chat from any page.