### PR TITLE
Add email/password and Google OAuth authentication with django-allauth

### DIFF
--- a/canna/settings.py
+++ b/canna/settings.py
@@ -40,6 +40,11 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sitemaps',
+    'django.contrib.sites',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
     'users',
     'apps.strains',
     'apps.store',
@@ -50,9 +55,12 @@ INSTALLED_APPS = [
     'django_json_ld',
 ]
 
+SITE_ID = 1
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
     'canna.middleware.GeoLanguageMiddleware',  # IP-based language detection (BEFORE LocaleMiddleware)
     'django.middleware.locale.LocaleMiddleware',  # LocaleMiddleware processes language preference
     'canna.middleware.AdminEnglishMiddleware',  # Override for admin (after LocaleMiddleware)
@@ -210,6 +218,40 @@ STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = "users.CustomUser"
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
+# django-allauth
+ACCOUNT_USER_MODEL_USERNAME_FIELD = None
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = False
+ACCOUNT_LOGIN_METHODS = {'email'}
+ACCOUNT_EMAIL_VERIFICATION = 'optional'
+ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
+ACCOUNT_UNIQUE_EMAIL = True
+ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = True
+
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'
+ACCOUNT_LOGOUT_REDIRECT_URL = '/'
+
+# Google OAuth
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': ['profile', 'email'],
+        'AUTH_PARAMS': {'access_type': 'online'},
+        'APP': {
+            'client_id': os.environ.get('GOOGLE_OAUTH_CLIENT_ID', ''),
+            'secret': os.environ.get('GOOGLE_OAUTH_SECRET', ''),
+        },
+    }
+}
+
+# Email backend (console for development, override in production)
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 TINYMCE_DEFAULT_CONFIG = {
     "height": "320px",

--- a/canna/urls.py
+++ b/canna/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
 # EN (new):     /en/strain/... - WITH /en/ prefix
 urlpatterns += i18n_patterns(
     path('jsi18n/', JavaScriptCatalog.as_view(domain='django'), name='javascript-catalog'),
+    path('accounts/', include('allauth.urls')),
     path('', include('apps.strains.urls')),
     path('store/', include('apps.store.urls')),
     path('api/chat/', include('apps.chat_bot.urls')),

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -592,6 +592,185 @@ msgstr "Search results"
 msgid "Continuar chat"
 msgstr "Resume chat"
 
+#: templates/account/login.html templates/account/password_reset_from_key_done.html
+#: templates/account/email_confirm.html templates/base_v2.html
+msgid "Iniciar sesión"
+msgstr "Sign in"
+
+#: templates/account/login.html
+msgid "¿No tienes cuenta?"
+msgstr "Don't have an account?"
+
+#: templates/account/login.html
+msgid "Regístrate"
+msgstr "Sign up"
+
+#: templates/account/login.html templates/account/signup.html
+msgid "Continuar con Google"
+msgstr "Continue with Google"
+
+#: templates/account/login.html templates/account/signup.html
+msgid "o"
+msgstr "or"
+
+#: templates/account/login.html templates/account/signup.html
+#: templates/account/password_reset.html
+msgid "Correo electrónico"
+msgstr "Email"
+
+#: templates/account/login.html templates/account/signup.html
+msgid "Contraseña"
+msgstr "Password"
+
+#: templates/account/login.html
+msgid "¿Olvidaste tu contraseña?"
+msgstr "Forgot your password?"
+
+#: templates/account/signup.html templates/base_v2.html
+msgid "Crear cuenta"
+msgstr "Create account"
+
+#: templates/account/signup.html
+msgid "¿Ya tienes cuenta?"
+msgstr "Already have an account?"
+
+#: templates/account/signup.html
+msgid "Inicia sesión"
+msgstr "Sign in"
+
+#: templates/account/signup.html
+msgid "Confirmar contraseña"
+msgstr "Confirm password"
+
+#: templates/account/logout.html templates/base_v2.html
+msgid "Cerrar sesión"
+msgstr "Sign out"
+
+#: templates/account/logout.html
+msgid "¿Estás seguro de que quieres cerrar sesión?"
+msgstr "Are you sure you want to sign out?"
+
+#: templates/account/logout.html
+msgid "Volver al inicio"
+msgstr "Back to home"
+
+#: templates/account/password_reset.html
+msgid "Restablecer contraseña"
+msgstr "Reset password"
+
+#: templates/account/password_reset.html
+msgid "Ingresa tu correo electrónico y te enviaremos un enlace para restablecer tu contraseña."
+msgstr "Enter your email and we'll send you a link to reset your password."
+
+#: templates/account/password_reset.html
+msgid "Enviar enlace"
+msgstr "Send link"
+
+#: templates/account/password_reset.html templates/account/password_reset_done.html
+#: templates/socialaccount/login_cancelled.html
+msgid "Volver a iniciar sesión"
+msgstr "Back to sign in"
+
+#: templates/account/password_reset_done.html
+msgid "Correo enviado"
+msgstr "Email sent"
+
+#: templates/account/password_reset_done.html
+msgid "Revisa tu correo"
+msgstr "Check your email"
+
+#: templates/account/password_reset_done.html
+msgid "Te hemos enviado un correo electrónico con instrucciones para restablecer tu contraseña. Si no lo ves, revisa tu carpeta de spam."
+msgstr "We've sent you an email with instructions to reset your password. If you don't see it, check your spam folder."
+
+#: templates/account/password_reset_from_key.html
+msgid "Nueva contraseña"
+msgstr "New password"
+
+#: templates/account/password_reset_from_key.html
+msgid "Ingresa tu nueva contraseña a continuación."
+msgstr "Enter your new password below."
+
+#: templates/account/password_reset_from_key.html
+msgid "Este enlace para restablecer la contraseña ha expirado o no es válido. Por favor solicita uno nuevo."
+msgstr "This password reset link has expired or is invalid. Please request a new one."
+
+#: templates/account/password_reset_from_key.html
+msgid "Solicitar nuevo enlace"
+msgstr "Request new link"
+
+#: templates/account/password_reset_from_key.html
+msgid "Confirmar nueva contraseña"
+msgstr "Confirm new password"
+
+#: templates/account/password_reset_from_key.html
+msgid "Cambiar contraseña"
+msgstr "Change password"
+
+#: templates/account/password_reset_from_key_done.html
+msgid "Contraseña actualizada"
+msgstr "Password updated"
+
+#: templates/account/password_reset_from_key_done.html
+msgid "Tu contraseña ha sido actualizada exitosamente. Ya puedes iniciar sesión con tu nueva contraseña."
+msgstr "Your password has been updated successfully. You can now sign in with your new password."
+
+#: templates/account/email_confirm.html
+msgid "Confirmar correo electrónico"
+msgstr "Confirm email address"
+
+#: templates/account/email_confirm.html
+msgid "Confirmar"
+msgstr "Confirm"
+
+#: templates/account/email_confirm.html
+msgid "Este enlace de confirmación ha expirado o no es válido."
+msgstr "This confirmation link has expired or is invalid."
+
+#: templates/account/email_confirm.html
+msgid "Por favor confirma que <strong>%(email)s</strong> es tu dirección de correo electrónico."
+msgstr "Please confirm that <strong>%(email)s</strong> is your email address."
+
+#: templates/account/verification_sent.html
+msgid "Verificación enviada"
+msgstr "Verification sent"
+
+#: templates/account/verification_sent.html
+msgid "Verifica tu correo"
+msgstr "Verify your email"
+
+#: templates/account/verification_sent.html
+msgid "Te hemos enviado un correo de verificación. Por favor revisa tu bandeja de entrada y haz clic en el enlace para activar tu cuenta."
+msgstr "We've sent you a verification email. Please check your inbox and click the link to activate your account."
+
+#: templates/account/verification_sent.html
+msgid "Si no ves el correo, revisa tu carpeta de spam."
+msgstr "If you don't see the email, check your spam folder."
+
+#: templates/account/login.html templates/account/signup.html
+msgid "Cerrar"
+msgstr "Close"
+
+#: templates/socialaccount/login.html
+msgid "Iniciar sesión con Google"
+msgstr "Sign in with Google"
+
+#: templates/socialaccount/login.html
+msgid "Vas a iniciar sesión con tu cuenta de %(provider_name)s."
+msgstr "You are about to sign in using your %(provider_name)s account."
+
+#: templates/socialaccount/login.html
+msgid "Continuar"
+msgstr "Continue"
+
+#: templates/socialaccount/login_cancelled.html
+msgid "Inicio de sesión cancelado"
+msgstr "Sign in cancelled"
+
+#: templates/socialaccount/login_cancelled.html
+msgid "Has cancelado el inicio de sesión con tu cuenta social. Puedes intentarlo de nuevo o usar tu correo y contraseña."
+msgstr "You have cancelled the social login. You can try again or use your email and password."
+
 #~ msgid "Efectos"
 #~ msgstr "Effects"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ sqlparse==0.5.5
 tomli==2.3.0
 typing_extensions>=4.11
 urllib3==2.6.3
+django-allauth[socialaccount]==65.4.1

--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -1,0 +1,496 @@
+/* ==========================================================================
+   Auth Pages — Dark Theme Styles
+   Matches Cannamente v2 "Digital Botanical" design system.
+   Uses CSS custom properties from styles_v2.css.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   Layout
+   -------------------------------------------------------------------------- */
+.auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 200px);
+  padding: 60px var(--section-pad-x) 80px;
+}
+
+/* --------------------------------------------------------------------------
+   Card (glassmorphic container)
+   -------------------------------------------------------------------------- */
+.auth-card {
+  width: 100%;
+  max-width: 440px;
+  background: rgba(26, 34, 32, 0.7);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 48px 40px;
+  box-shadow:
+    0 4px 32px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+}
+
+.auth-card__header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.auth-card__title {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.auth-card__subtitle {
+  font-size: 0.938rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.auth-card__subtitle a {
+  color: var(--accent-green);
+  font-weight: 500;
+}
+
+.auth-card__subtitle a:hover {
+  text-decoration: underline;
+}
+
+/* --------------------------------------------------------------------------
+   Form Elements
+   -------------------------------------------------------------------------- */
+.auth-form .form-group {
+  margin-bottom: 20px;
+}
+
+.auth-form label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.auth-form input[type="text"],
+.auth-form input[type="email"],
+.auth-form input[type="password"] {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  transition: border-color 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+}
+
+.auth-form input[type="text"]::placeholder,
+.auth-form input[type="email"]::placeholder,
+.auth-form input[type="password"]::placeholder {
+  color: var(--text-muted);
+}
+
+.auth-form input[type="text"]:focus,
+.auth-form input[type="email"]:focus,
+.auth-form input[type="password"]:focus {
+  outline: none;
+  border-color: var(--accent-green);
+  box-shadow: 0 0 0 3px var(--accent-green-dim);
+}
+
+/* Help text under fields */
+.auth-form .helptext,
+.auth-form .help-text {
+  display: block;
+  font-size: 0.813rem;
+  color: var(--text-muted);
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
+.auth-form .helptext ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.auth-form .helptext ul li {
+  margin-bottom: 2px;
+}
+
+/* Checkbox styling */
+.auth-form input[type="checkbox"] {
+  accent-color: var(--accent-green);
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+/* --------------------------------------------------------------------------
+   Buttons
+   -------------------------------------------------------------------------- */
+.auth-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 24px;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  border: none;
+  cursor: pointer;
+  transition: all 0.25s var(--ease-out);
+}
+
+.auth-btn--primary {
+  background: var(--accent-green);
+  color: var(--bg-primary);
+}
+
+.auth-btn--primary:hover {
+  background: #00c864;
+  box-shadow: 0 4px 16px rgba(0, 230, 118, 0.3);
+}
+
+.auth-btn--primary:active {
+  transform: scale(0.98);
+}
+
+.auth-btn--secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border-light);
+}
+
+.auth-btn--secondary:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+  background: var(--accent-green-dim);
+}
+
+/* --------------------------------------------------------------------------
+   Social Login (Google)
+   -------------------------------------------------------------------------- */
+.auth-social {
+  margin-bottom: 24px;
+}
+
+.auth-social__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 24px;
+  font-family: var(--font-body);
+  font-size: 0.938rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.25s var(--ease-out);
+}
+
+.auth-social__btn:hover {
+  border-color: var(--text-secondary);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.auth-social__btn svg {
+  flex-shrink: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Divider ("or" separator)
+   -------------------------------------------------------------------------- */
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}
+
+.auth-divider__text {
+  font-size: 0.813rem;
+  color: var(--text-muted);
+  text-transform: lowercase;
+}
+
+/* --------------------------------------------------------------------------
+   Error Messages
+   -------------------------------------------------------------------------- */
+.auth-errors {
+  background: rgba(220, 38, 38, 0.1);
+  border: 1px solid rgba(220, 38, 38, 0.25);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  margin-bottom: 20px;
+}
+
+.auth-errors ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.auth-errors li {
+  font-size: 0.875rem;
+  color: #f87171;
+  line-height: 1.5;
+}
+
+.auth-errors li + li {
+  margin-top: 4px;
+}
+
+/* Per-field errors */
+.auth-form .errorlist {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+}
+
+.auth-form .errorlist li {
+  font-size: 0.813rem;
+  color: #f87171;
+  line-height: 1.4;
+}
+
+/* --------------------------------------------------------------------------
+   Links & Extras
+   -------------------------------------------------------------------------- */
+.auth-card__footer {
+  text-align: center;
+  margin-top: 24px;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.auth-card__footer a {
+  color: var(--accent-green);
+  font-weight: 500;
+}
+
+.auth-card__footer a:hover {
+  text-decoration: underline;
+}
+
+.auth-forgot-link {
+  display: block;
+  text-align: right;
+  font-size: 0.813rem;
+  color: var(--text-secondary);
+  margin-top: -12px;
+  margin-bottom: 24px;
+}
+
+.auth-forgot-link:hover {
+  color: var(--accent-green);
+}
+
+/* --------------------------------------------------------------------------
+   Success / Info Messages
+   -------------------------------------------------------------------------- */
+.auth-message {
+  text-align: center;
+  padding: 16px;
+}
+
+.auth-message__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 20px;
+  border-radius: 50%;
+  background: var(--accent-green-dim);
+}
+
+.auth-message__icon svg {
+  color: var(--accent-green);
+}
+
+.auth-message__text {
+  font-size: 0.938rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+/* --------------------------------------------------------------------------
+   Navbar Auth Items
+   -------------------------------------------------------------------------- */
+.header-v2__auth {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: 8px;
+}
+
+.header-v2__auth-link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: color 0.2s var(--ease-out);
+  white-space: nowrap;
+}
+
+.header-v2__auth-link:hover {
+  color: var(--accent-green);
+}
+
+.header-v2__auth-link--login {
+  padding: 6px 16px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-pill);
+  color: var(--text-primary);
+}
+
+.header-v2__auth-link--login:hover {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+  background: var(--accent-green-dim);
+}
+
+.header-v2__user {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.header-v2__user-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--accent-green-dim);
+  color: var(--accent-green);
+  font-weight: 600;
+  font-size: 0.813rem;
+}
+
+.header-v2__user-logout {
+  font-size: 0.813rem;
+  color: var(--text-muted);
+  margin-left: 4px;
+}
+
+.header-v2__user-logout:hover {
+  color: #f87171;
+}
+
+/* Mobile auth in nav overlay */
+.header-v2__mobile-auth {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.header-v2__mobile-auth .auth-btn {
+  font-size: 0.938rem;
+  padding: 12px 20px;
+}
+
+.header-v2__mobile-auth .auth-btn--primary {
+  color: #0a0f0a;
+}
+
+/* --------------------------------------------------------------------------
+   Close button on auth pages
+   -------------------------------------------------------------------------- */
+.auth-card__close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: all 0.2s var(--ease-out);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.auth-card__close:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.auth-card {
+  position: relative;
+}
+
+/* --------------------------------------------------------------------------
+   Responsive
+   -------------------------------------------------------------------------- */
+@media (max-width: 768px) {
+  .auth-page {
+    padding: 40px 16px 60px;
+    min-height: calc(100vh - 160px);
+  }
+
+  .auth-card {
+    padding: 32px 24px;
+  }
+
+  .auth-card__title {
+    font-size: 1.5rem;
+  }
+
+  /* Hide desktop auth items, show mobile */
+  .header-v2__auth {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .auth-card {
+    padding: 28px 20px;
+    border-radius: var(--radius-md);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Reduced motion
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .auth-btn,
+  .auth-social__btn,
+  .auth-form input {
+    transition: none;
+  }
+}

--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -1,0 +1,43 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Confirmar correo electrónico" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Confirmar correo electrónico" %}</h1>
+    </div>
+
+    {% if confirmation %}
+    <div class="auth-message">
+      <p class="auth-message__text">
+        {% blocktrans with email=confirmation.email_address.email %}
+        Por favor confirma que <strong>{{ email }}</strong> es tu dirección de correo electrónico.
+        {% endblocktrans %}
+      </p>
+
+      <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+        {% csrf_token %}
+        <button type="submit" class="auth-btn auth-btn--primary">{% trans "Confirmar" %}</button>
+      </form>
+    </div>
+    {% else %}
+    <div class="auth-errors">
+      <ul>
+        <li>{% trans "Este enlace de confirmación ha expirado o no es válido." %}</li>
+      </ul>
+    </div>
+    <div class="auth-card__footer">
+      <a href="{% url 'account_login' %}">{% trans "Iniciar sesión" %}</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,87 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+{% load socialaccount %}
+
+{% block title %}{% trans "Iniciar sesión" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <a href="/" class="auth-card__close" aria-label="{% trans 'Cerrar' %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+    </a>
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Iniciar sesión" %}</h1>
+      <p class="auth-card__subtitle">
+        {% trans "¿No tienes cuenta?" %}
+        <a href="{% url 'account_signup' %}">{% trans "Regístrate" %}</a>
+      </p>
+    </div>
+
+    <!-- Social login -->
+    <div class="auth-social">
+      <a href="{% provider_login_url 'google' %}" class="auth-social__btn">
+        <svg width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A11.96 11.96 0 001 12c0 1.94.46 3.77 1.18 5.07l3.66-2.84v-.14z" fill="#FBBC05"/>
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+        </svg>
+        {% trans "Continuar con Google" %}
+      </a>
+    </div>
+
+    <div class="auth-divider">
+      <span class="auth-divider__text">{% trans "o" %}</span>
+    </div>
+
+    <!-- Login form -->
+    {% if form.non_field_errors %}
+    <div class="auth-errors">
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <form method="post" action="{% url 'account_login' %}" class="auth-form">
+      {% csrf_token %}
+
+      <div class="form-group">
+        <label for="{{ form.login.id_for_label }}">{% trans "Correo electrónico" %}</label>
+        {{ form.login }}
+        {% if form.login.errors %}
+        <ul class="errorlist">
+          {% for error in form.login.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.password.id_for_label }}">{% trans "Contraseña" %}</label>
+        {{ form.password }}
+        {% if form.password.errors %}
+        <ul class="errorlist">
+          {% for error in form.password.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <a href="{% url 'account_reset_password' %}" class="auth-forgot-link">{% trans "¿Olvidaste tu contraseña?" %}</a>
+
+      {% if redirect_field_value %}
+      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+      {% endif %}
+
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Iniciar sesión" %}</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -1,0 +1,31 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Cerrar sesión" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Cerrar sesión" %}</h1>
+      <p class="auth-card__subtitle">
+        {% trans "¿Estás seguro de que quieres cerrar sesión?" %}
+      </p>
+    </div>
+
+    <form method="post" action="{% url 'account_logout' %}">
+      {% csrf_token %}
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Cerrar sesión" %}</button>
+    </form>
+
+    <div class="auth-card__footer">
+      <a href="/">{% trans "Volver al inicio" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,0 +1,52 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Restablecer contraseña" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Restablecer contraseña" %}</h1>
+      <p class="auth-card__subtitle">
+        {% trans "Ingresa tu correo electrónico y te enviaremos un enlace para restablecer tu contraseña." %}
+      </p>
+    </div>
+
+    {% if form.non_field_errors %}
+    <div class="auth-errors">
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <form method="post" action="{% url 'account_reset_password' %}" class="auth-form">
+      {% csrf_token %}
+
+      <div class="form-group">
+        <label for="{{ form.email.id_for_label }}">{% trans "Correo electrónico" %}</label>
+        {{ form.email }}
+        {% if form.email.errors %}
+        <ul class="errorlist">
+          {% for error in form.email.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Enviar enlace" %}</button>
+    </form>
+
+    <div class="auth-card__footer">
+      <a href="{% url 'account_login' %}">{% trans "Volver a iniciar sesión" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -1,0 +1,32 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Correo enviado" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Revisa tu correo" %}</h1>
+    </div>
+
+    <div class="auth-message">
+      <div class="auth-message__icon">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect width="20" height="16" x="2" y="4" rx="2"/>
+          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+        </svg>
+      </div>
+      <p class="auth-message__text">
+        {% trans "Te hemos enviado un correo electrónico con instrucciones para restablecer tu contraseña. Si no lo ves, revisa tu carpeta de spam." %}
+      </p>
+      <a href="{% url 'account_login' %}" class="auth-btn auth-btn--secondary">{% trans "Volver a iniciar sesión" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -1,0 +1,73 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Nueva contraseña" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Nueva contraseña" %}</h1>
+      <p class="auth-card__subtitle">
+        {% trans "Ingresa tu nueva contraseña a continuación." %}
+      </p>
+    </div>
+
+    {% if token_fail %}
+    <div class="auth-errors">
+      <ul>
+        <li>{% trans "Este enlace para restablecer la contraseña ha expirado o no es válido. Por favor solicita uno nuevo." %}</li>
+      </ul>
+    </div>
+    <div class="auth-card__footer">
+      <a href="{% url 'account_reset_password' %}">{% trans "Solicitar nuevo enlace" %}</a>
+    </div>
+    {% else %}
+
+    {% if form.non_field_errors %}
+    <div class="auth-errors">
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <form method="post" action="{{ action_url }}" class="auth-form">
+      {% csrf_token %}
+
+      <div class="form-group">
+        <label for="{{ form.password1.id_for_label }}">{% trans "Nueva contraseña" %}</label>
+        {{ form.password1 }}
+        {% if form.password1.help_text %}
+        <span class="help-text">{{ form.password1.help_text }}</span>
+        {% endif %}
+        {% if form.password1.errors %}
+        <ul class="errorlist">
+          {% for error in form.password1.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.password2.id_for_label }}">{% trans "Confirmar nueva contraseña" %}</label>
+        {{ form.password2 }}
+        {% if form.password2.errors %}
+        <ul class="errorlist">
+          {% for error in form.password2.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Cambiar contraseña" %}</button>
+    </form>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,31 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Contraseña actualizada" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Contraseña actualizada" %}</h1>
+    </div>
+
+    <div class="auth-message">
+      <div class="auth-message__icon">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M20 6 9 17l-5-5"/>
+        </svg>
+      </div>
+      <p class="auth-message__text">
+        {% trans "Tu contraseña ha sido actualizada exitosamente. Ya puedes iniciar sesión con tu nueva contraseña." %}
+      </p>
+      <a href="{% url 'account_login' %}" class="auth-btn auth-btn--primary">{% trans "Iniciar sesión" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,0 +1,98 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+{% load socialaccount %}
+
+{% block title %}{% trans "Crear cuenta" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <a href="/" class="auth-card__close" aria-label="{% trans 'Cerrar' %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+    </a>
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Crear cuenta" %}</h1>
+      <p class="auth-card__subtitle">
+        {% trans "¿Ya tienes cuenta?" %}
+        <a href="{% url 'account_login' %}">{% trans "Inicia sesión" %}</a>
+      </p>
+    </div>
+
+    <!-- Social signup -->
+    <div class="auth-social">
+      <a href="{% provider_login_url 'google' %}" class="auth-social__btn">
+        <svg width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A11.96 11.96 0 001 12c0 1.94.46 3.77 1.18 5.07l3.66-2.84v-.14z" fill="#FBBC05"/>
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+        </svg>
+        {% trans "Continuar con Google" %}
+      </a>
+    </div>
+
+    <div class="auth-divider">
+      <span class="auth-divider__text">{% trans "o" %}</span>
+    </div>
+
+    <!-- Signup form -->
+    {% if form.non_field_errors %}
+    <div class="auth-errors">
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <form method="post" action="{% url 'account_signup' %}" class="auth-form">
+      {% csrf_token %}
+
+      <div class="form-group">
+        <label for="{{ form.email.id_for_label }}">{% trans "Correo electrónico" %}</label>
+        {{ form.email }}
+        {% if form.email.errors %}
+        <ul class="errorlist">
+          {% for error in form.email.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.password1.id_for_label }}">{% trans "Contraseña" %}</label>
+        {{ form.password1 }}
+        {% if form.password1.help_text %}
+        <span class="help-text">{{ form.password1.help_text }}</span>
+        {% endif %}
+        {% if form.password1.errors %}
+        <ul class="errorlist">
+          {% for error in form.password1.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.password2.id_for_label }}">{% trans "Confirmar contraseña" %}</label>
+        {{ form.password2 }}
+        {% if form.password2.errors %}
+        <ul class="errorlist">
+          {% for error in form.password2.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      {% if redirect_field_value %}
+      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+      {% endif %}
+
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Crear cuenta" %}</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/verification_sent.html
+++ b/templates/account/verification_sent.html
@@ -1,0 +1,34 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Verificación enviada" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Verifica tu correo" %}</h1>
+    </div>
+
+    <div class="auth-message">
+      <div class="auth-message__icon">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect width="20" height="16" x="2" y="4" rx="2"/>
+          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+        </svg>
+      </div>
+      <p class="auth-message__text">
+        {% trans "Te hemos enviado un correo de verificación. Por favor revisa tu bandeja de entrada y haz clic en el enlace para activar tu cuenta." %}
+      </p>
+      <p class="auth-message__text">
+        {% trans "Si no ves el correo, revisa tu carpeta de spam." %}
+      </p>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/base_v2.html
+++ b/templates/base_v2.html
@@ -58,6 +58,7 @@
 
     <!-- New dark theme styles -->
     <link rel="stylesheet" type="text/css" href="{% static 'css/styles_v2.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
 
     {% block extra_css %}{% endblock %}
 </head>
@@ -117,6 +118,18 @@
                         {% endif %}
                     {% endfor %}
                 </div>
+                <div class="header-v2__mobile-auth">
+                    {% if user.is_authenticated %}
+                    <span class="header-v2__user">
+                        <span class="header-v2__user-icon">{{ user.email|first|upper }}</span>
+                        {{ user.email }}
+                    </span>
+                    <a href="{% url 'account_logout' %}" class="auth-btn auth-btn--secondary">{% trans "Cerrar sesión" %}</a>
+                    {% else %}
+                    <a href="{% url 'account_login' %}" class="auth-btn auth-btn--primary">{% trans "Iniciar sesión" %}</a>
+                    <a href="{% url 'account_signup' %}" class="auth-btn auth-btn--secondary">{% trans "Crear cuenta" %}</a>
+                    {% endif %}
+                </div>
             </div>
         </nav>
 
@@ -148,6 +161,19 @@
                         <a href="{% alt_url lang_code %}" class="header-v2__lang-option">{{ lang_code|upper }}</a>
                     {% endif %}
                 {% endfor %}
+            </div>
+
+            <div class="header-v2__auth">
+                {% if user.is_authenticated %}
+                <span class="header-v2__user">
+                    <span class="header-v2__user-icon">{{ user.email|first|upper }}</span>
+                    <a href="{% url 'account_logout' %}" class="header-v2__user-logout" aria-label="{% trans 'Cerrar sesión' %}">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                    </a>
+                </span>
+                {% else %}
+                <a href="{% url 'account_login' %}" class="header-v2__auth-link header-v2__auth-link--login">{% trans "Iniciar sesión" %}</a>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -1,0 +1,34 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Iniciar sesión con Google" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <a href="{% url 'account_login' %}" class="auth-card__close" aria-label="{% trans 'Cerrar' %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+    </a>
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Iniciar sesión con Google" %}</h1>
+      <p class="auth-card__subtitle">
+        {% blocktrans with provider_name=provider.name %}Vas a iniciar sesión con tu cuenta de {{ provider_name }}.{% endblocktrans %}
+      </p>
+    </div>
+
+    <form method="post">
+      {% csrf_token %}
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Continuar" %}</button>
+    </form>
+
+    <div class="auth-card__footer">
+      <a href="{% url 'account_login' %}">{% trans "Volver a iniciar sesión" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/socialaccount/login_cancelled.html
+++ b/templates/socialaccount/login_cancelled.html
@@ -1,0 +1,26 @@
+{% extends "base_v2.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Inicio de sesión cancelado" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Inicio de sesión cancelado" %}</h1>
+    </div>
+
+    <div class="auth-message">
+      <p class="auth-message__text">
+        {% trans "Has cancelado el inicio de sesión con tu cuenta social. Puedes intentarlo de nuevo o usar tu correo y contraseña." %}
+      </p>
+      <a href="{% url 'account_login' %}" class="auth-btn auth-btn--primary">{% trans "Volver a iniciar sesión" %}</a>
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
Integrate django-allauth for user authentication with email/password login, registration, password reset, and Google OAuth support. Includes bilingual (ES/EN) auth templates in dark theme, navbar auth links, and styled socialaccount pages.