### PR TITLE
Skip /api/ paths in language middleware to prevent unnecessary proces…

### DIFF
--- a/canna/middleware.py
+++ b/canna/middleware.py
@@ -41,7 +41,7 @@ class AdminEnglishMiddleware:
 
     def __call__(self, request):
         # Force English for admin panel
-        if request.path.startswith('/admin/'):
+        if request.path.startswith('/manage-canna/'):
             translation.activate('en')
             request.LANGUAGE_CODE = 'en'
 
@@ -49,7 +49,7 @@ class AdminEnglishMiddleware:
 
         # Ensure response has English set for admin
         # (in case view code changed language during request processing)
-        if request.path.startswith('/admin/'):
+        if request.path.startswith('/manage-canna/'):
             translation.activate('en')
 
         return response
@@ -95,7 +95,7 @@ class LanguageUrlRedirectMiddleware:
 
     def _should_skip(self, path):
         skip_prefixes = [
-            '/admin/',
+            '/manage-canna/',
             '/api/',
             '/i18n/',
             '/static/',
@@ -103,6 +103,7 @@ class LanguageUrlRedirectMiddleware:
             '/tinymce/',
             '/robots.txt',
             '/favicon.ico',
+            '/sitemap.xml',
             '/cookie-consent/',
         ]
 
@@ -168,7 +169,7 @@ class GeoLanguageMiddleware:
     def _should_skip(self, path):
         """Skip certain paths that don't need language detection"""
         skip_prefixes = [
-            '/admin/',
+            '/manage-canna/',
             '/api/',
             '/i18n/',
             '/static/',

--- a/canna/middleware.py
+++ b/canna/middleware.py
@@ -96,6 +96,7 @@ class LanguageUrlRedirectMiddleware:
     def _should_skip(self, path):
         skip_prefixes = [
             '/admin/',
+            '/api/',
             '/i18n/',
             '/static/',
             '/media/',
@@ -168,6 +169,7 @@ class GeoLanguageMiddleware:
         """Skip certain paths that don't need language detection"""
         skip_prefixes = [
             '/admin/',
+            '/api/',
             '/i18n/',
             '/static/',
             '/media/',


### PR DESCRIPTION
…sing

API endpoints (chat, etc.) don't need GeoLanguageMiddleware or LanguageUrlRedirectMiddleware — language is determined by the client payload, not the URL prefix.