### PR TITLE
Fix 404 errors from links to inactive strains in genetics tree and te…

### DIFF
--- a/apps/strains/templatetags/translate.py
+++ b/apps/strains/templatetags/translate.py
@@ -1,7 +1,16 @@
+import re
+
 from django import template
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 register = template.Library()
+
+# Matches <a href="/strain/slug/"> or <a href="/en/strain/slug/">
+_STRAIN_LINK_RE = re.compile(
+    r'<a\b([^>]*href=["\'](?:/(?:en/)?strain/([\w-]+)/)["\'][^>]*)>(.*?)</a>',
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 @register.filter
@@ -85,3 +94,40 @@ def alt_url(context, lang_code):
     else:
         # Other languages get prefix
         return f'/{lang_code}{path_without_lang}'
+
+
+@register.filter
+def deactivate_strain_links(html):
+    """
+    Replace <a> links to inactive strains with plain <span> tags.
+
+    Parses all strain links in the HTML, checks which slugs are active
+    in one DB query, and replaces inactive ones with styled spans.
+    """
+    if not html:
+        return html
+
+    text = str(html)
+    matches = list(_STRAIN_LINK_RE.finditer(text))
+    if not matches:
+        return html
+
+    # Collect unique slugs from all matches
+    slugs = {m.group(2) for m in matches}
+
+    # Single DB query: get set of active slugs
+    from apps.strains.models import Strain
+    active_slugs = set(
+        Strain.objects.filter(slug__in=slugs, active=True)
+        .values_list('slug', flat=True)
+    )
+
+    def _replace(match):
+        slug = match.group(2)
+        if slug in active_slugs:
+            return match.group(0)  # keep link as-is
+        link_text = match.group(3)
+        return f'<span class="strain-link-inactive">{link_text}</span>'
+
+    result = _STRAIN_LINK_RE.sub(_replace, text)
+    return mark_safe(result)

--- a/static/css/articles-v2.css
+++ b/static/css/articles-v2.css
@@ -548,6 +548,12 @@
     color: var(--article-link-hover);
 }
 
+.article-detail-v2__content .strain-link-inactive {
+    color: var(--text-muted);
+    text-decoration: none;
+    cursor: default;
+}
+
 .article-detail-v2__content strong {
     color: var(--article-text);
     font-weight: 600;

--- a/static/css/strain-detail-v2.css
+++ b/static/css/strain-detail-v2.css
@@ -210,6 +210,11 @@ h1.sd-name:before {
     color: #69f0ae;
 }
 
+.sd-top__desc .tovar_text .strain-link-inactive {
+    color: var(--text-muted);
+    cursor: default;
+}
+
 /* --- Section --- */
 .sd-section {
     margin-bottom: 28px;
@@ -459,6 +464,12 @@ h1.sd-name:before {
     background: var(--text-muted);
     font-style: italic;
     opacity: 0.5;
+}
+
+.sd-genetics__node--inactive {
+    background: var(--text-muted);
+    opacity: 0.5;
+    cursor: default;
 }
 
 .sd-genetics__node--current {

--- a/static/css/styles_v2.css
+++ b/static/css/styles_v2.css
@@ -2159,6 +2159,11 @@ select:focus-visible,
   text-decoration: underline;
 }
 
+.terpene-detail-v2__content .strain-link-inactive {
+  color: var(--text-muted);
+  cursor: default;
+}
+
 .terpene-detail-v2__content ul,
 .terpene-detail-v2__content ol {
   padding-left: 24px;

--- a/templates/article_detail_v2.html
+++ b/templates/article_detail_v2.html
@@ -1,6 +1,7 @@
 {% extends "base_v2.html" %}
 {% load static %}
 {% load i18n %}
+{% load translate %}
 
 {% block title %}
     {{ article.title }}
@@ -150,7 +151,7 @@
                     {% endif %}
 
                     <div class="article-detail-v2__content">
-                        {{ article.text_content|safe }}
+                        {{ article.text_content|deactivate_strain_links }}
                     </div>
 
                     {% if featured_strains %}

--- a/templates/strain_modern_v2.html
+++ b/templates/strain_modern_v2.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load json_ld %}
 {% load i18n %}
+{% load translate %}
 
 {% block title %}
     {{ strain.name }} {% trans "cepas de marihuana" %}
@@ -74,7 +75,7 @@
                 {% endif %}
             </div>
             <div class="sd-top__desc">
-                <div class="tovar_text">{{ strain.text_content|safe }}</div>
+                <div class="tovar_text">{{ strain.text_content|deactivate_strain_links }}</div>
             </div>
         </div>
 
@@ -223,7 +224,11 @@
             <div class="sd-genetics" id="genetics-tree">
                 <div class="sd-genetics__parents" id="genetics-parents">
                     {% for parent in strain.parents.all %}
+                    {% if parent.active %}
                     <a href="{% url 'strain_detail' parent.slug %}" class="sd-genetics__node sd-genetics__node--parent">{{ parent.name }}</a>
+                    {% else %}
+                    <span class="sd-genetics__node sd-genetics__node--inactive">{{ parent.name }}</span>
+                    {% endif %}
                     {% endfor %}
                     {% if strain.parents.count == 1 %}
                     <span class="sd-genetics__node sd-genetics__node--unknown">{% trans "Desconocido" %}</span>

--- a/templates/terpene_detail_v2.html
+++ b/templates/terpene_detail_v2.html
@@ -1,6 +1,7 @@
 {% extends "base_v2.html" %}
 {% load static %}
 {% load i18n %}
+{% load translate %}
 
 {% block title %}
     {% blocktrans with name=terpene.title %}Descripción y propiedades del terpeno {{ name }}{% endblocktrans %}
@@ -45,7 +46,7 @@
                 {% endif %}
 
                 <div class="terpene-detail-v2__content">
-                    {{ terpene.text_content|safe }}
+                    {{ terpene.text_content|deactivate_strain_links }}
                 </div>
             </article>
 


### PR DESCRIPTION
- Genetics tree: render inactive parent strains as plain <span> instead of <a> links
- Text content: add deactivate_strain_links template filter that replaces links to inactive strains with styled spans (single DB query per page render)
- Applied filter to strain, article, and terpene detail templates
- Links automatically reactivate when strains become active=True