### PR TITLE
Feature/text copywriter

### DIFF
--- a/apps/strains/admin.py
+++ b/apps/strains/admin.py
@@ -17,7 +17,12 @@ from apps.strains.models import (
     Flavor,
     Terpene,
 )
-from apps.strains.leafly_import import get_copywriter, CopywritingError
+from apps.strains.copywriter import (
+    CopywritingError,
+    get_copywriter_for_content_type,
+    get_handler,
+)
+from apps.strains.llm_output import clean_generated_output
 from apps.strains.signals import perform_translation
 from apps.translation import get_translator
 from apps.translation.base_translator import TranslationError
@@ -44,11 +49,13 @@ class StrainAdminForm(TranslatedModelForm):
         fields = '__all__'
 
 
-class StrainCopywriterForm(forms.Form):
-    strain = forms.ModelChoiceField(
-        queryset=Strain.objects.order_by('name'),
+class CopywriterForm(forms.Form):
+    """Generic copywriter form, parameterized by content type."""
+
+    target_object = forms.ModelChoiceField(
+        queryset=Strain.objects.none(),
         required=False,
-        label='Strain (optional)',
+        label='Target (optional)',
     )
     source_text = forms.CharField(
         widget=forms.Textarea(attrs={'rows': 8, 'style': 'width: 100%;'}),
@@ -68,11 +75,17 @@ class StrainCopywriterForm(forms.Form):
     confirm_overwrite = forms.BooleanField(
         required=False,
         label='Confirm overwrite',
-        help_text='Check to overwrite the selected strain text.',
+        help_text='Check to overwrite the selected object text.',
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, content_type='strain', **kwargs):
         super().__init__(*args, **kwargs)
+        handler = get_handler(content_type)
+        model_class = handler['_model_class']
+        self.fields['target_object'].queryset = model_class.objects.order_by(
+            handler['queryset_order']
+        )
+        self.fields['target_object'].label = f'{handler["label"]} (optional)'
         self.fields['generated_text_en'].widget.attrs['readonly'] = True
         self.fields['generated_text_es'].widget.attrs['readonly'] = True
 
@@ -123,13 +136,134 @@ class TranslatedModelAdmin(TranslationAdmin):
     translation_status_badge.short_description = 'Translation Status'
 
 
+class CopywriterAdminMixin:
+    """Mixin that adds a copywriter view to any TranslatedModelAdmin."""
+
+    copywriter_content_type = None  # Set in subclass: 'strain', 'terpene', 'article'
+
+    def get_urls(self):
+        urls = super().get_urls()
+        if self.copywriter_content_type:
+            custom_urls = [
+                path(
+                    'copywriter/',
+                    self.admin_site.admin_view(self.copywriter_view),
+                    name=f'strains_{self.copywriter_content_type}_copywriter',
+                ),
+            ]
+            return custom_urls + urls
+        return urls
+
+    def copywriter_view(self, request):
+        ct = self.copywriter_content_type
+        handler = get_handler(ct)
+        form = CopywriterForm(content_type=ct)
+
+        if request.method == 'POST':
+            action = request.POST.get('action')
+            form = CopywriterForm(request.POST, content_type=ct)
+
+            if not form.is_valid():
+                self.message_user(request, 'Please correct the errors below.', level=messages.ERROR)
+            else:
+                target_obj = form.cleaned_data['target_object']
+                source_text = form.cleaned_data['source_text']
+                generated_en = (form.cleaned_data.get('generated_text_en') or '').strip()
+                generated_es = (form.cleaned_data.get('generated_text_es') or '').strip()
+
+                if action == 'generate':
+                    try:
+                        copywriter = get_copywriter_for_content_type(ct)
+                        result = copywriter.generate(source_text, obj=target_obj, content_type=ct)
+                        generated_en = clean_generated_output(result.get(handler['output_key'], ''), ct)
+
+                        translator = get_translator()
+                        translations = translator.translate(
+                            handler['translate_model_name'],
+                            {handler['translate_field']: generated_en},
+                            'en',
+                            'es',
+                        )
+                        generated_es = clean_generated_output(
+                            translations.get(handler['translate_field']) or '',
+                            ct,
+                        )
+                        if not generated_es:
+                            raise TranslationError('Translation returned empty text')
+
+                        form = CopywriterForm(
+                            initial={
+                                'target_object': target_obj.id if target_obj else None,
+                                'source_text': source_text,
+                                'generated_text_en': generated_en,
+                                'generated_text_es': generated_es,
+                            },
+                            content_type=ct,
+                        )
+                    except (CopywritingError, TranslationError, ValueError) as exc:
+                        self.message_user(request, f'Generation failed: {exc}', level=messages.ERROR)
+
+                elif action == 'apply':
+                    if generated_en:
+                        generated_en = clean_generated_output(generated_en, ct)
+                    if generated_es:
+                        generated_es = clean_generated_output(generated_es, ct)
+                    if not target_obj:
+                        form.add_error('target_object', f'Select a {handler["label"].lower()} to overwrite.')
+                    if not form.cleaned_data.get('confirm_overwrite'):
+                        form.add_error('confirm_overwrite', 'Confirmation is required.')
+                    if not generated_en or not generated_es:
+                        form.add_error(None, 'Generate text first before applying.')
+
+                    if not form.errors:
+                        target_field = handler['target_field']
+                        en_field = f'{target_field}_en'
+                        es_field = f'{target_field}_es'
+
+                        setattr(target_obj, target_field, generated_en)
+                        setattr(target_obj, en_field, generated_en)
+                        setattr(target_obj, es_field, generated_es)
+                        target_obj.translation_status = 'synced'
+                        target_obj.translation_error = None
+                        target_obj.last_translated_at = timezone.now()
+                        target_obj.translation_source_hash = target_obj.get_translatable_content_hash()
+                        target_obj._skip_translation_check = True
+
+                        update_fields = [
+                            target_field, en_field, es_field,
+                            'translation_status', 'translation_error',
+                            'last_translated_at', 'translation_source_hash',
+                        ]
+                        if hasattr(target_obj, 'updated_at'):
+                            update_fields.append('updated_at')
+                        target_obj.save(update_fields=update_fields)
+
+                        obj_name = getattr(target_obj, handler['name_field'], str(target_obj))
+                        self.message_user(
+                            request,
+                            f'Text updated for {obj_name}.',
+                            level=messages.SUCCESS,
+                        )
+                else:
+                    self.message_user(request, 'Unknown action.', level=messages.ERROR)
+
+        context = {
+            **self.admin_site.each_context(request),
+            'form': form,
+            'title': f'{handler["label"]} Copywriter',
+            'content_type_label': handler['label'],
+        }
+        return render(request, 'admin/strains/copywriter.html', context)
+
+
 class AlternativeNameInline(admin.TabularInline):
     model = AlternativeStrainName
     extra = 1
 
 
-class StrainAdmin(TranslatedModelAdmin):
+class StrainAdmin(CopywriterAdminMixin, TranslatedModelAdmin):
     form = StrainAdminForm
+    copywriter_content_type = 'strain'
     change_list_template = 'admin/strains/strain/change_list.html'
     list_display = (
         'name',
@@ -152,109 +286,6 @@ class StrainAdmin(TranslatedModelAdmin):
     inlines = [AlternativeNameInline]
     actions = ['force_retranslate']
 
-    def get_urls(self):
-        urls = super().get_urls()
-        custom_urls = [
-            path(
-                'copywriter/',
-                self.admin_site.admin_view(self.copywriter_view),
-                name='strains_strain_copywriter',
-            ),
-        ]
-        return custom_urls + urls
-
-    def copywriter_view(self, request):
-        form = StrainCopywriterForm()
-        if request.method == 'POST':
-            action = request.POST.get('action')
-            form = StrainCopywriterForm(request.POST)
-
-            if not form.is_valid():
-                self.message_user(
-                    request,
-                    'Please correct the errors below.',
-                    level=messages.ERROR,
-                )
-            else:
-                strain = form.cleaned_data['strain']
-                source_text = form.cleaned_data['source_text']
-                generated_en = (form.cleaned_data.get('generated_text_en') or '').strip()
-                generated_es = (form.cleaned_data.get('generated_text_es') or '').strip()
-
-                if action == 'generate':
-                    try:
-                        copywriter = get_copywriter()
-                        generated_en = copywriter.rewrite_raw_text(
-                            source_text,
-                            strain_name=strain.name if strain else None,
-                        )
-                        translator = get_translator()
-                        translations = translator.translate(
-                            'Strain',
-                            {'text_content': generated_en},
-                            'en',
-                            'es',
-                        )
-                        generated_es = (translations.get('text_content') or '').strip()
-                        if not generated_es:
-                            raise TranslationError('Translation returned empty text_content')
-
-                        form = StrainCopywriterForm(initial={
-                            'strain': strain.id if strain else None,
-                            'source_text': source_text,
-                            'generated_text_en': generated_en,
-                            'generated_text_es': generated_es,
-                        })
-                    except (CopywritingError, TranslationError, ValueError) as exc:
-                        self.message_user(request, f'Generation failed: {exc}', level=messages.ERROR)
-
-                elif action == 'apply':
-                    if not strain:
-                        form.add_error('strain', 'Select a strain to overwrite.')
-                    if not form.cleaned_data.get('confirm_overwrite'):
-                        form.add_error('confirm_overwrite', 'Confirmation is required.')
-                    if not generated_en or not generated_es:
-                        form.add_error(None, 'Generate text first before applying.')
-
-                    if not form.errors:
-                        strain.text_content = generated_en
-                        strain.text_content_en = generated_en
-                        strain.text_content_es = generated_es
-                        strain.translation_status = 'synced'
-                        strain.translation_error = None
-                        strain.last_translated_at = timezone.now()
-                        strain.translation_source_hash = strain.get_translatable_content_hash()
-                        strain._skip_translation_check = True
-                        strain.save(update_fields=[
-                            'text_content',
-                            'text_content_en',
-                            'text_content_es',
-                            'translation_status',
-                            'translation_error',
-                            'last_translated_at',
-                            'translation_source_hash',
-                            'updated_at',
-                        ])
-                        self.message_user(
-                            request,
-                            f'Text updated for {strain.name}.',
-                            level=messages.SUCCESS,
-                        )
-
-                else:
-                    self.message_user(
-                        request,
-                        'Unknown action. Use Generate or Apply.',
-                        level=messages.ERROR,
-                    )
-
-        context = {
-            **self.admin_site.each_context(request),
-            'form': form,
-            'title': 'Strain Copywriter',
-        }
-        return render(request, 'admin/strains/strain/copywriter.html', context)
-
     @admin.action(description='Force retranslate selected items')
     def force_retranslate(self, request, queryset):
         """Force retranslate selected items"""
@@ -272,8 +303,10 @@ class ArticleImageInline(admin.TabularInline):
     extra = 1
 
 
-class ArticleAdmin(TranslatedModelAdmin):
+class ArticleAdmin(CopywriterAdminMixin, TranslatedModelAdmin):
     form = ArticleAdminForm
+    copywriter_content_type = 'article'
+    change_list_template = 'admin/strains/article/change_list.html'
     inlines = [ArticleImageInline]
     list_display = ('title_display', 'translation_status_badge', 'last_translated_at')
     search_fields = ('title_en', 'title_es')
@@ -306,8 +339,10 @@ class ArticleAdmin(TranslatedModelAdmin):
         self.message_user(request, f'{count} articles translated successfully')
 
 
-class TerpeneAdmin(TranslatedModelAdmin):
+class TerpeneAdmin(CopywriterAdminMixin, TranslatedModelAdmin):
     form = TerpeneAdminForm
+    copywriter_content_type = 'terpene'
+    change_list_template = 'admin/strains/terpene/change_list.html'
     list_display = ('name', 'translation_status_badge', 'last_translated_at')
     search_fields = ('name',)  # name is NOT translated (Limonene, Myrcene, etc.)
     actions = ['force_retranslate']

--- a/apps/strains/copywriter.py
+++ b/apps/strains/copywriter.py
@@ -1,0 +1,163 @@
+"""
+Generic copywriter service for admin-driven text generation.
+
+Uses static prompt configuration from copywriter_config and delegates
+to the OpenAI API via openai_compat.
+"""
+
+import json
+
+from apps.strains.copywriter_config import get_config
+from apps.strains.llm_output import clean_generated_output, strip_code_fences
+from apps.translation.config import TranslationConfig
+from apps.translation.openai_compat import create_chat_completion
+
+
+# ---------------------------------------------------------------------------
+# Content-type handler registry
+# ---------------------------------------------------------------------------
+
+def _get_model_class(content_type: str):
+    """Lazy import to avoid circular imports."""
+    from apps.strains.models import Strain, Article, Terpene
+    return {'strain': Strain, 'article': Article, 'terpene': Terpene}[content_type]
+
+
+def _build_strain_payload(source_text: str, obj=None) -> str:
+    payload = {
+        'strain_name': obj.name if obj else '',
+        'description_source': source_text,
+        'target_length': len(source_text),
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _build_terpene_payload(source_text: str, obj=None) -> str:
+    payload = {
+        'terpene_name': obj.name if obj else '',
+        'description_source': source_text,
+        'target_length': len(source_text),
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _build_article_payload(source_text: str, obj=None) -> str:
+    payload = {
+        'article_title': (obj.title_en or obj.title or '') if obj else '',
+        'description_source': source_text,
+        'target_length': len(source_text),
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+CONTENT_TYPE_HANDLERS = {
+    'strain': {
+        'label': 'Strain',
+        'name_field': 'name',
+        'queryset_order': 'name',
+        'build_payload': _build_strain_payload,
+        'output_key': 'text_content',
+        'target_field': 'text_content',
+        'translate_model_name': 'Strain',
+        'translate_field': 'text_content',
+    },
+    'terpene': {
+        'label': 'Terpene',
+        'name_field': 'name',
+        'queryset_order': 'name',
+        'build_payload': _build_terpene_payload,
+        'output_key': 'description',
+        'target_field': 'description',
+        'translate_model_name': 'Terpene',
+        'translate_field': 'description',
+    },
+    'article': {
+        'label': 'Article',
+        'name_field': 'title_en',
+        'queryset_order': 'title_en',
+        'build_payload': _build_article_payload,
+        'output_key': 'text_content',
+        'target_field': 'text_content',
+        'translate_model_name': 'Article',
+        'translate_field': 'text_content',
+    },
+}
+
+
+def get_handler(content_type: str) -> dict:
+    """Return handler dict with lazily resolved _model_class."""
+    handler = CONTENT_TYPE_HANDLERS.get(content_type)
+    if not handler:
+        raise ValueError(f'Unknown content type: {content_type}')
+    if '_model_class' not in handler:
+        handler['_model_class'] = _get_model_class(content_type)
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Generic copywriter
+# ---------------------------------------------------------------------------
+
+class CopywritingError(Exception):
+    pass
+
+
+class GenericCopywriter:
+    """LLM copywriter using static config from copywriter_config."""
+
+    def __init__(self, config: dict):
+        self.system_prompt = config['system_prompt']
+        self.model = config['model']
+        self.temperature = config['temperature']
+        self.max_tokens = config['max_tokens']
+        self._init_client()
+
+    def _init_client(self):
+        from openai import OpenAI
+        self.client = OpenAI(
+            api_key=TranslationConfig.OPENAI_API_KEY,
+            timeout=TranslationConfig.OPENAI_TIMEOUT,
+        )
+
+    def generate(self, source_text: str, obj=None, content_type: str = '') -> dict:
+        handler = get_handler(content_type)
+        user_payload = handler['build_payload'](source_text, obj)
+        result = self._generate_json(user_payload)
+
+        output_key = handler['output_key']
+        text = result.get(output_key, '')
+        if not str(text).strip():
+            raise CopywritingError(f'LLM returned empty {output_key}')
+
+        result[output_key] = clean_generated_output(str(text).strip(), content_type)
+        return result
+
+    def _generate_json(self, user_payload: str) -> dict:
+        raw = self._call_model(user_payload)
+        raw = strip_code_fences(raw)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise CopywritingError(f'Invalid JSON from LLM: {exc}') from exc
+
+    def _call_model(self, user_payload: str) -> str:
+        from openai import OpenAIError
+        try:
+            response = create_chat_completion(
+                self.client,
+                model=self.model,
+                messages=[
+                    {'role': 'system', 'content': self.system_prompt},
+                    {'role': 'user', 'content': user_payload},
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+        except OpenAIError as exc:
+            raise CopywritingError(str(exc)) from exc
+        return response.choices[0].message.content.strip()
+
+
+def get_copywriter_for_content_type(content_type: str) -> GenericCopywriter:
+    """Factory: return a copywriter configured from static config."""
+    config = get_config(content_type)
+    return GenericCopywriter(config)

--- a/apps/strains/copywriter_config.py
+++ b/apps/strains/copywriter_config.py
@@ -1,0 +1,249 @@
+"""
+Static copywriter configuration.
+
+All prompts, model settings, and parameters are fixed here after experimental
+validation (see git history for experiment results). Changes to prompts should
+go through code review, not DB edits.
+"""
+
+# ---------------------------------------------------------------------------
+# LLM defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = 'gpt-5.4'
+DEFAULT_TEMPERATURE = 0.5
+DEFAULT_MAX_TOKENS = 4000
+
+# ---------------------------------------------------------------------------
+# Strain prompt
+# ---------------------------------------------------------------------------
+
+STRAIN_SYSTEM_PROMPT = (
+    "You are a human editor maintaining a cannabis strain product database.\n"
+    "\n"
+    "Task:\n"
+    "Rewrite the provided source description into original, publication-ready English copy for a product page.\n"
+    "\n"
+    "Hard rules:\n"
+    "1) Use ONLY facts explicitly present in the source text.\n"
+    "2) Preserve all strain names and genetics references EXACTLY as written.\n"
+    "3) Preserve the source meaning, order of ideas, and density of useful detail.\n"
+    "4) Rewrite the wording substantially enough that the source is not recognizable sentence by sentence.\n"
+    "5) Do NOT compress the text into a short summary. Output exactly one <p>...</p> block and keep the length close to target_length (+/-10%).\n"
+    "6) Do NOT include links, URLs, or brand mentions.\n"
+    "7) Use only ASCII punctuation.\n"
+    "8) Identify alternative names ONLY if explicitly stated as 'also known as' or 'aka'.\n"
+    "9) Do not use any HTML tags other than the outer <p> tag.\n"
+    "\n"
+    "Source note:\n"
+    "- The source text may be a merged excerpt from two different descriptions.\n"
+    "- It can contain repeated or near-duplicate statements. Deduplicate aggressively.\n"
+    "- It can contain conflicting claims (e.g., sleepy vs energetic). Do NOT reconcile; omit conflicting claims entirely.\n"
+    "- When duplicates exist, prefer medically framed statements (conditions/symptoms/therapeutic context) if they are not contradicted.\n"
+    "- Prefer details that are stated clearly and consistently across the text. If unsure, leave it out.\n"
+    "- Keep the strongest factual details from the original instead of replacing them with generic copy.\n"
+    "- Do not mention that multiple sources were used.\n"
+    "- Do NOT include market availability, legal/illegal market, pricing, or distribution context.\n"
+    "- Geographic origin or breeding location is allowed ONLY if stated explicitly as origin/lineage/cultivation history.\n"
+    "Examples:\n"
+    '- EXCLUDE: "Skywalker is most commonly found on the West Coast, in Arizona, and in Colorado. '
+    "But it's relatively easy to find on any legal market, as well as the black market in many parts of the country.\"\n"
+    '- ALLOW: "This strain was first cultivated in California."\n'
+    "\n"
+    "Banned AI vocabulary (never use these words):\n"
+    "landscape, interplay, testament, tapestry, multifaceted, pivotal, cornerstone,\n"
+    "renowned, paradigm, leverage, comprehensive, robust, nuanced, intricate,\n"
+    "innovative, holistic, synergy, delve, elevate, captivating, embark, foster,\n"
+    "moreover, furthermore, notably, it's worth noting, it should be mentioned.\n"
+    "\n"
+    "Banned AI patterns:\n"
+    "- Do NOT list three things in a row (rule-of-three). Two or four is fine.\n"
+    "- Do NOT say the same thing in different words (synonym cycling).\n"
+    "- Do NOT use 'not just X but Y' or 'not only X but also Y' parallelisms.\n"
+    "- Do NOT hedge with phrases like 'it's worth noting' or 'it should be mentioned'.\n"
+    "- Do NOT use signposting: 'Let's explore', 'In this section', 'As we can see'.\n"
+    "- Do NOT write a concluding or summarizing sentence.\n"
+    "\n"
+    "Language constraints:\n"
+    "- Do NOT use promotional or marketing language.\n"
+    "- Avoid generic SEO phrases such as 'popular choice', 'ideal', 'renowned', or similar wording.\n"
+    "- Do NOT summarize or conclude the paragraph.\n"
+    "- Keep specific claims specific. Do not blur them into vague category language.\n"
+    "\n"
+    "Style constraints:\n"
+    "- Write like a human editor updating a product catalog entry.\n"
+    "- Do NOT use an educational or encyclopedic tone.\n"
+    "- Sentence structure should feel slightly uneven.\n"
+    "- Vary sentence length noticeably.\n"
+    "- One sentence may be short or slightly imperfect.\n"
+    "- Avoid perfectly balanced or symmetrical phrasing.\n"
+    "- Do NOT start sentences with 'With', 'Although', or 'However'.\n"
+    "\n"
+    "Output format:\n"
+    "Return ONLY a JSON object with the following keys:\n"
+    "- text_content (string, containing the <p>...</p> paragraph)\n"
+)
+
+# ---------------------------------------------------------------------------
+# Terpene prompt  (experimentally validated — single-pass editor approach)
+# ---------------------------------------------------------------------------
+
+TERPENE_SYSTEM_PROMPT = """\
+You are the lead content editor for a cannabis wellness website. A junior writer submitted
+a rough draft about a terpene. Your job: reshape it into a polished page that could go
+live today.
+
+You are NOT paraphrasing. You are editing: restructuring, tightening, adding voice. The
+facts come from the draft; the writing comes from you.
+
+EXAMPLE OF BAD OUTPUT (do NOT produce anything like this):
+---
+Cendrene is a sesquiterpene with a fresh aroma that carries a slight woody note. [...]
+The oil has served many purposes over the centuries. [...] The oil is also given a broad
+place in holistic medicine. [...] found encouraging results [...] Cendrene is found most
+often in cedarwood oil, carries historical ties to the Middle East, and may have value as
+an anti-tumor agent and as an astringent.
+---
+
+WHY IT'S BAD:
+- "has served many purposes over the centuries" -- empty filler, says nothing
+- "given a broad place in holistic medicine" -- vague and passive
+- "found encouraging results" -- timid hedge instead of naming the result
+- Final sentence is a recap that adds zero new information
+- Follows the source paragraph-by-paragraph like a paraphrase exercise
+
+EXAMPLE OF GOOD STYLE (different terpene, for illustration only):
+---
+Myrcene smells like ripe mangoes and fresh hops. It is the most abundant terpene in
+modern cannabis cultivars, sometimes making up more than 50% of a plant's terpene
+profile.
+
+Brewers know it well. Myrcene gives hops their earthy, peppery kick -- and it crosses
+into dozens of other plants, from lemongrass to wild thyme. A rodent study showed oral
+myrcene reduced inflammation markers by 40% at moderate doses.
+
+In cannabis, myrcene may amplify THC's sedative effects. Strains heavy in myrcene tend
+to produce the deep-body calm many users associate with indicas.
+---
+
+WHY IT'S GOOD:
+- Opens with sensory detail, not a classification sentence
+- Specific facts instead of vague claims
+- Short sentences mixed with longer ones
+- No summary paragraph -- ends on substantive content
+- Reads like a knowledgeable writer, not a cautious paraphraser
+
+EDITING RULES:
+- Open with the most interesting or sensory detail, not a dictionary definition.
+- Group related facts into coherent paragraphs. You MAY reorganize; you are NOT required
+  to follow the draft's section order.
+- Replace EVERY vague claim with a concrete specific.
+  "various purposes" -> name the purposes. "encouraging results" -> state the result.
+- At least 30% of sentences should be under 12 words.
+- Never start two consecutive sentences the same way.
+- Use active voice. Prefer "Cedrene does X" over "X is done by cedrene".
+- The LAST paragraph must contain substantive content -- NOT a recap, summary, or
+  "bottom line". Do NOT write any sentence starting with "Overall", "In summary",
+  "In conclusion", "Most commonly", or "To sum up".
+- Never use the words "draft", "source", "article", or "passage" in your output.
+
+FACTUAL RULES (CRITICAL):
+- Use ONLY facts present in the submitted draft. Add ZERO new claims.
+- Do not invent strain names, study dates, percentages, or advice not in the draft.
+- Do not mention "entourage effect", "ask your budtender", or other concepts absent
+  from the draft.
+- Use the canonical terpene name provided for every mention.
+
+Output format:
+Return ONLY a JSON object with the key:
+- description (string, the rewritten description as plain text with paragraph breaks)
+"""
+
+# ---------------------------------------------------------------------------
+# Article prompt
+# ---------------------------------------------------------------------------
+
+ARTICLE_SYSTEM_PROMPT = (
+    "You are a human editor maintaining a cannabis information website.\n"
+    "\n"
+    "Task:\n"
+    "Rewrite the provided source text into original, publication-ready English content for an article page.\n"
+    "\n"
+    "Hard rules:\n"
+    "1) Use ONLY facts explicitly present in the source text.\n"
+    "2) Preserve all strain names, chemical names, and scientific references EXACTLY.\n"
+    "3) Preserve the source meaning, order of sections, and level of detail.\n"
+    "4) Rewrite the wording substantially enough that the source is not recognizable sentence by sentence.\n"
+    "5) Do NOT compress the article into a summary. Keep the overall length close to the source (+/-15%).\n"
+    "6) HTML is allowed: <p>, <h3>, <ul>, <li>, <strong>, <em>. No other tags.\n"
+    "7) Preserve the structural role of each block. If the source has section headings or list-like blocks, keep that structure in the rewrite.\n"
+    "8) Do NOT include links, URLs, or brand mentions.\n"
+    "9) Use only ASCII punctuation.\n"
+    "10) Keep heading count modest and functional. Do not invent decorative headings.\n"
+    "\n"
+    "Structure rules:\n"
+    "- Keep ideas in roughly the same sequence as the source.\n"
+    "- Preserve factual distinctions and caveats instead of flattening them.\n"
+    "- Remove repetition, filler, and obvious redundancy, but do not strip out substantive material.\n"
+    "- If the source contains a list of concrete items, preserve that as a list when useful.\n"
+    "\n"
+    "Banned AI vocabulary (never use these words):\n"
+    "landscape, interplay, testament, tapestry, multifaceted, pivotal, cornerstone,\n"
+    "renowned, paradigm, leverage, comprehensive, robust, nuanced, intricate,\n"
+    "innovative, holistic, synergy, delve, elevate, captivating, embark, foster,\n"
+    "moreover, furthermore, notably, it's worth noting, it should be mentioned.\n"
+    "\n"
+    "Banned AI patterns:\n"
+    "- Do NOT list three things in a row (rule-of-three). Two or four is fine.\n"
+    "- Do NOT say the same thing in different words (synonym cycling).\n"
+    "- Do NOT use 'not just X but Y' or 'not only X but also Y' parallelisms.\n"
+    "- Do NOT hedge with phrases like 'it's worth noting' or 'it should be mentioned'.\n"
+    "- Do NOT write a concluding or summarizing sentence.\n"
+    "- Do NOT use signposting: 'Let's explore', 'In this section', 'As we can see'.\n"
+    "- Do NOT flatten a multi-section source into a uniform wall of text.\n"
+    "\n"
+    "Style constraints:\n"
+    "- Write like a human editor updating an informational article.\n"
+    "- Sentence structure should feel slightly uneven.\n"
+    "- Vary sentence length noticeably.\n"
+    "- Do NOT use an educational or encyclopedic tone.\n"
+    "- Do NOT start sentences with 'With', 'Although', or 'However'.\n"
+    "- Prefer specific wording from the facts over generic editorial filler.\n"
+    "\n"
+    "Output format:\n"
+    "Return ONLY a JSON object with the key:\n"
+    "- text_content (string, the rewritten HTML content)\n"
+)
+
+# ---------------------------------------------------------------------------
+# Per-content-type config lookup
+# ---------------------------------------------------------------------------
+
+COPYWRITER_CONFIGS = {
+    'strain': {
+        'system_prompt': STRAIN_SYSTEM_PROMPT,
+        'model': DEFAULT_MODEL,
+        'temperature': DEFAULT_TEMPERATURE,
+        'max_tokens': DEFAULT_MAX_TOKENS,
+    },
+    'terpene': {
+        'system_prompt': TERPENE_SYSTEM_PROMPT,
+        'model': DEFAULT_MODEL,
+        'temperature': DEFAULT_TEMPERATURE,
+        'max_tokens': DEFAULT_MAX_TOKENS,
+    },
+    'article': {
+        'system_prompt': ARTICLE_SYSTEM_PROMPT,
+        'model': DEFAULT_MODEL,
+        'temperature': DEFAULT_TEMPERATURE,
+        'max_tokens': DEFAULT_MAX_TOKENS,
+    },
+}
+
+
+def get_config(content_type: str) -> dict:
+    """Return copywriter config for a content type."""
+    config = COPYWRITER_CONFIGS.get(content_type)
+    if not config:
+        raise ValueError(f'Unknown content type: {content_type}')
+    return config

--- a/apps/strains/leafly_import.py
+++ b/apps/strains/leafly_import.py
@@ -25,16 +25,16 @@ from apps.strains.models import (
 )
 from apps.translation import TranslationConfig, get_translator
 from apps.translation.base_translator import TranslationError
+from apps.translation.openai_compat import create_chat_completion
+from apps.strains.llm_output import (
+    clean_generated_output,
+    normalize_ascii_punctuation as shared_normalize_ascii_punctuation,
+    strip_code_fences as shared_strip_code_fences,
+)
 
 
 def _strip_code_fences(content: str) -> str:
-    if content.startswith('```'):
-        lines = content.split('\n')
-        lines = lines[1:]
-        if lines and lines[-1].strip() == '```':
-            lines = lines[:-1]
-        return '\n'.join(lines).strip()
-    return content
+    return shared_strip_code_fences(content)
 
 
 class LeaflyFetchError(Exception):
@@ -707,10 +707,7 @@ class _CopywriterOutputMixin:
         except json.JSONDecodeError as exc:
             raise CopywritingError(f'Invalid JSON from copywriter: {exc}') from exc
 
-        text_content = str(result.get('text_content', '')).strip()
-        text_content = self._normalize_ascii_punctuation(text_content)
-        text_content = self._strip_links(text_content)
-        text_content = self._ensure_paragraph(text_content)
+        text_content = clean_generated_output(result.get('text_content', ''), 'strain')
 
         img_alt_text = str(result.get('img_alt_text', '')).strip()
         img_alt_text = self._normalize_ascii_punctuation(img_alt_text)
@@ -747,19 +744,7 @@ class _CopywriterOutputMixin:
         return str(soup)
 
     def _normalize_ascii_punctuation(self, text: str) -> str:
-        replacements = {
-            '\u2018': "'",
-            '\u2019': "'",
-            '\u201c': '"',
-            '\u201d': '"',
-            '\u2013': '-',
-            '\u2014': '-',
-            '\u2026': '...',
-            '\u00a0': ' ',
-        }
-        for original, replacement in replacements.items():
-            text = text.replace(original, replacement)
-        return text
+        return shared_normalize_ascii_punctuation(text)
 
     def _clean_alternative_names(self, primary: str, names: List[str]) -> List[str]:
         cleaned = []
@@ -895,7 +880,8 @@ class LeaflyCopywriter(_CopywriterOutputMixin):
         from openai import OpenAIError
         user_prompt = self._build_payload(parsed)
         try:
-            response = self.client.chat.completions.create(
+            response = create_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "system", "content": self.SYSTEM_PROMPT},
@@ -923,7 +909,8 @@ class LeaflyCopywriter(_CopywriterOutputMixin):
         }, ensure_ascii=False, indent=2)
 
         try:
-            response = self.client.chat.completions.create(
+            response = create_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "system", "content": self.SYSTEM_PROMPT},
@@ -949,7 +936,8 @@ class LeaflyCopywriter(_CopywriterOutputMixin):
         numbered = '\n'.join(f'{i + 1}. {r}' for i, r in enumerate(reviews))
         prompt = f'Strain: {strain_name}\n\nUser reviews:\n{numbered}'
         try:
-            response = self.client.chat.completions.create(
+            response = create_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "system", "content": REVIEW_SUMMARY_SYSTEM_PROMPT},
@@ -1089,7 +1077,8 @@ class TaxonomyTranslator:
                 )
                 content = response.content[0].text.strip()
             else:
-                response = self._client.chat.completions.create(
+                response = create_chat_completion(
+                    self._client,
                     model=self.model,
                     messages=[
                         {"role": "system", "content": system_prompt},

--- a/apps/strains/llm_output.py
+++ b/apps/strains/llm_output.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+import re
+
+from bs4 import BeautifulSoup, Comment
+
+logger = logging.getLogger(__name__)
+
+AI_WORDS = {
+    'landscape', 'interplay', 'testament', 'tapestry', 'multifaceted',
+    'pivotal', 'cornerstone', 'renowned', 'paradigm', 'leverage',
+    'comprehensive', 'robust', 'nuanced', 'intricate', 'innovative',
+    'holistic', 'synergy', 'delve', 'elevate', 'captivating', 'embark',
+    'foster', 'moreover', 'furthermore', 'notably',
+}
+
+
+def strip_code_fences(content: str) -> str:
+    if content.startswith('```'):
+        lines = content.split('\n')
+        lines = lines[1:]
+        if lines and lines[-1].strip() == '```':
+            lines = lines[:-1]
+        return '\n'.join(lines).strip()
+    return content
+
+
+def normalize_ascii_punctuation(text: str) -> str:
+    replacements = {
+        '\u2018': "'",
+        '\u2019': "'",
+        '\u201c': '"',
+        '\u201d': '"',
+        '\u2013': '-',
+        '\u2014': '-',
+        '\u2026': '...',
+        '\u00a0': ' ',
+    }
+    for original, replacement in replacements.items():
+        text = text.replace(original, replacement)
+    return text
+
+
+def _check_ai_words(text: str) -> list[str]:
+    lower = text.lower()
+    return [word for word in AI_WORDS if re.search(rf'\b{word}\b', lower)]
+
+
+def humanize_text(text: str) -> str:
+    text = normalize_ascii_punctuation(text)
+    found = _check_ai_words(text)
+    if found:
+        logger.warning('AI words detected in copywriter output: %s', ', '.join(found))
+    return text
+
+
+def strip_links(text: str) -> str:
+    soup = BeautifulSoup(text, 'html.parser')
+    for anchor in soup.find_all('a'):
+        anchor.replace_with(anchor.get_text(' ', strip=True))
+    return _render_html(soup)
+
+
+def ensure_paragraph(text: str) -> str:
+    stripped = text.strip()
+    if stripped.lower().startswith('<p>') and stripped.lower().endswith('</p>'):
+        return stripped
+    return f'<p>{stripped}</p>'
+
+
+def sanitize_html(
+    text: str,
+    *,
+    allowed_tags: set[str],
+    allowed_attrs: dict[str, set[str]] | None = None,
+) -> str:
+    soup = BeautifulSoup(text, 'html.parser')
+
+    for comment in soup.find_all(string=lambda value: isinstance(value, Comment)):
+        comment.extract()
+
+    for tag in soup.find_all(True):
+        tag_name = tag.name.lower()
+        if tag_name in {'script', 'style'}:
+            tag.decompose()
+            continue
+        if tag_name not in allowed_tags:
+            tag.unwrap()
+            continue
+
+        allowed_for_tag = (allowed_attrs or {}).get(tag_name, set())
+        for attr_name in list(tag.attrs):
+            if attr_name not in allowed_for_tag:
+                del tag.attrs[attr_name]
+
+    return _render_html(soup)
+
+
+def clean_generated_output(text: str, content_type: str) -> str:
+    cleaned = humanize_text(str(text or '').strip())
+
+    if content_type == 'terpene':
+        cleaned = strip_links(cleaned)
+        cleaned = BeautifulSoup(cleaned, 'html.parser').get_text('\n')
+        return _normalize_plain_text_blocks(cleaned)
+
+    cleaned = strip_links(cleaned)
+
+    if content_type == 'strain':
+        cleaned = sanitize_html(cleaned, allowed_tags={'p'})
+        return ensure_paragraph(cleaned)
+
+    if content_type == 'article':
+        cleaned = sanitize_html(
+            cleaned,
+            allowed_tags={'p', 'h3', 'ul', 'li', 'strong', 'em'},
+        )
+        return cleaned.strip()
+
+    raise ValueError(f'Unknown content type: {content_type}')
+
+
+def _render_html(soup: BeautifulSoup) -> str:
+    container = soup.body if soup.body else soup
+    return ''.join(str(child) for child in container.contents).strip()
+
+
+def _normalize_plain_text_blocks(text: str) -> str:
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    normalized_lines: list[str] = []
+
+    for raw_line in text.split('\n'):
+        line = re.sub(r'\s+', ' ', raw_line).strip()
+        if not line:
+            if normalized_lines and normalized_lines[-1] != '':
+                normalized_lines.append('')
+            continue
+        normalized_lines.append(line)
+
+    while normalized_lines and normalized_lines[-1] == '':
+        normalized_lines.pop()
+
+    return '\n'.join(normalized_lines)

--- a/apps/strains/management/commands/extract_genetics.py
+++ b/apps/strains/management/commands/extract_genetics.py
@@ -10,6 +10,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from apps.strains.models import AlternativeStrainName, Strain
 from apps.translation.config import TranslationConfig
+from apps.translation.openai_compat import create_chat_completion
 
 SYSTEM_PROMPT = """You are a cannabis genetics expert. You analyze strain descriptions and extract genetic lineage information.
 Return ONLY valid JSON, no explanations."""
@@ -303,7 +304,8 @@ class Command(BaseCommand):
         )
 
         try:
-            response = self.client.chat.completions.create(
+            response = create_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},

--- a/apps/strains/models.py
+++ b/apps/strains/models.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from tinymce.models import HTMLField
 
 from django.db import models
+
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.template.defaultfilters import slugify

--- a/apps/translation/openai_compat.py
+++ b/apps/translation/openai_compat.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from openai import OpenAIError
+
+
+def _prefers_max_completion_tokens(model: str) -> bool:
+    normalized = (model or '').strip().lower()
+    return normalized.startswith(('gpt-5', 'o1', 'o3', 'o4'))
+
+
+def _supports_retry(error: OpenAIError, unsupported_param: str, replacement_param: str) -> bool:
+    message = str(error)
+    return (
+        f"Unsupported parameter: '{unsupported_param}'" in message
+        and replacement_param in message
+    )
+
+
+def create_chat_completion(
+    client: Any,
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    **extra_kwargs: Any,
+) -> Any:
+    request_kwargs: dict[str, Any] = {
+        'model': model,
+        'messages': messages,
+        **extra_kwargs,
+    }
+    if temperature is not None:
+        request_kwargs['temperature'] = temperature
+
+    token_param: str | None = None
+    if max_tokens is not None:
+        token_param = 'max_completion_tokens' if _prefers_max_completion_tokens(model) else 'max_tokens'
+        request_kwargs[token_param] = max_tokens
+
+    try:
+        return client.chat.completions.create(**request_kwargs)
+    except OpenAIError as exc:
+        if (
+            token_param == 'max_tokens'
+            and max_tokens is not None
+            and _supports_retry(exc, 'max_tokens', 'max_completion_tokens')
+        ):
+            request_kwargs.pop('max_tokens', None)
+            request_kwargs['max_completion_tokens'] = max_tokens
+            return client.chat.completions.create(**request_kwargs)
+        if (
+            token_param == 'max_completion_tokens'
+            and max_tokens is not None
+            and _supports_retry(exc, 'max_completion_tokens', 'max_tokens')
+        ):
+            request_kwargs.pop('max_completion_tokens', None)
+            request_kwargs['max_tokens'] = max_tokens
+            return client.chat.completions.create(**request_kwargs)
+        raise

--- a/apps/translation/openai_translator.py
+++ b/apps/translation/openai_translator.py
@@ -18,6 +18,7 @@ from .base_translator import (
     TranslationParseError,
 )
 from .config import TranslationConfig
+from .openai_compat import create_chat_completion
 from .prompts import TranslationPrompts
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,8 @@ class OpenAITranslator(BaseTranslator):
             )
 
             # Call OpenAI API
-            response = self.client.chat.completions.create(
+            response = create_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},
@@ -131,7 +133,8 @@ class OpenAITranslator(BaseTranslator):
         """
         try:
             # Simple test with minimal tokens
-            response = self.client.chat.completions.create(
+            response = create_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "user", "content": "Hello"}

--- a/templates/admin/strains/article/change_list.html
+++ b/templates/admin/strains/article/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:strains_article_copywriter' %}" class="addlink">
+            {% trans "Article Copywriter" %}
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock %}

--- a/templates/admin/strains/copywriter.html
+++ b/templates/admin/strains/copywriter.html
@@ -1,0 +1,83 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+  <h1>{{ title }}</h1>
+
+  <form method="post" novalidate>
+    {% csrf_token %}
+
+    {% if form.non_field_errors %}
+      <div class="errornote">
+        {{ form.non_field_errors }}
+      </div>
+    {% endif %}
+
+    <fieldset class="module aligned">
+      <div class="form-row">
+        {{ form.target_object.label_tag }}<br>
+        {{ form.target_object }}
+        {% if form.target_object.errors %}
+          <div class="errors">{{ form.target_object.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-row">
+        {{ form.source_text.label_tag }}
+        {% if form.source_text.help_text %}
+          <div class="help">{{ form.source_text.help_text }}</div>
+        {% endif %}
+        {{ form.source_text }}
+        {% if form.source_text.errors %}
+          <div class="errors">{{ form.source_text.errors }}</div>
+        {% endif %}
+      </div>
+    </fieldset>
+
+    <fieldset class="module aligned">
+      <div class="form-row">
+        {{ form.generated_text_en.label_tag }}
+        {{ form.generated_text_en }}
+        {% if form.generated_text_en.errors %}
+          <div class="errors">{{ form.generated_text_en.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-row">
+        {{ form.generated_text_es.label_tag }}
+        {{ form.generated_text_es }}
+        {% if form.generated_text_es.errors %}
+          <div class="errors">{{ form.generated_text_es.errors }}</div>
+        {% endif %}
+      </div>
+    </fieldset>
+
+    <fieldset class="module aligned">
+      <div class="form-row">
+        {{ form.confirm_overwrite }}
+        {{ form.confirm_overwrite.label_tag }}
+        {% if form.confirm_overwrite.help_text %}
+          <div class="help">{{ form.confirm_overwrite.help_text }}</div>
+        {% endif %}
+        {% if form.confirm_overwrite.errors %}
+          <div class="errors">{{ form.confirm_overwrite.errors }}</div>
+        {% endif %}
+      </div>
+    </fieldset>
+
+    <div class="submit-row">
+      <button type="submit" name="action" value="generate" class="default">
+        {% trans "Generate" %}
+      </button>
+      {% if form.target_object.value %}
+        <button type="submit" name="action" value="apply">
+          {% trans "Apply to" %} {{ content_type_label|lower }}
+        </button>
+      {% else %}
+        <button type="button" disabled>
+          {% trans "Apply to" %} {{ content_type_label|lower }}
+        </button>
+      {% endif %}
+    </div>
+  </form>
+{% endblock %}

--- a/templates/admin/strains/terpene/change_list.html
+++ b/templates/admin/strains/terpene/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:strains_terpene_copywriter' %}" class="addlink">
+            {% trans "Terpene Copywriter" %}
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
- Generic copywriter for strain, terpene, article via admin
- Static prompt config in copywriter_config.py (gpt-5.4, t=0.5)
- Terpene: single-pass editor approach replacing 2-pass planner pipeline
- Shared llm_output helpers (sanitize, clean, humanize)
- openai_compat: handles max_completion_tokens for gpt-5+ models
- CopywriterPrompt DB model removed — prompts live in code (0022+0023)
- Admin copywriter view generic via CopywriterAdminMixin