### PR TITLE
Add email infrastructure: Brevo + Celery + allauth code verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,3 +121,9 @@ SENTRY_PROFILES_SAMPLE_RATE=0.1
 # Enable/disable the AI chat widget on the website
 # Set to 'true' to show the chat bubble, 'false' to hide it
 ENABLE_AI_CHAT=false
+
+
+BREVO_API_KEY=...
+DEFAULT_FROM_EMAIL=Cannamente <noreply@cannamente.com>
+EMAIL_BACKEND=anymail.backends.brevo.EmailBackend
+CELERY_BROKER_URL=redis://redis:6379/0

--- a/canna/__init__.py
+++ b/canna/__init__.py
@@ -1,0 +1,4 @@
+from .celery import app as celery_app
+
+
+__all__ = ('celery_app',)

--- a/canna/celery.py
+++ b/canna/celery.py
@@ -1,0 +1,10 @@
+import os
+
+from celery import Celery
+
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'canna.settings')
+
+app = Celery('canna')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()

--- a/canna/settings.py
+++ b/canna/settings.py
@@ -295,9 +295,17 @@ ANYMAIL = {
 }
 
 # Celery
+# When the console email backend is in use (the dev fallback), default to running
+# tasks eagerly so signup / password-reset work without needing a Redis broker.
+# Override explicitly with CELERY_TASK_ALWAYS_EAGER=True/False if you want to
+# exercise the broker locally with the console backend, or vice versa.
+_celery_eager_default = 'console' in EMAIL_BACKEND
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'redis://redis:6379/0')
 CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', '')
-CELERY_TASK_ALWAYS_EAGER = os.environ.get('CELERY_TASK_ALWAYS_EAGER', 'False') == 'True'
+CELERY_TASK_ALWAYS_EAGER = os.environ.get(
+    'CELERY_TASK_ALWAYS_EAGER',
+    'True' if _celery_eager_default else 'False',
+) == 'True'
 CELERY_TASK_EAGER_PROPAGATES = True
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ['json']

--- a/canna/settings.py
+++ b/canna/settings.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
     'storages',
     'tinymce',
     'django_json_ld',
+    'anymail',
 ]
 
 SITE_ID = 1
@@ -256,10 +257,12 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_LOGIN_METHODS = {'email'}
-ACCOUNT_EMAIL_VERIFICATION = 'optional'
+ACCOUNT_EMAIL_VERIFICATION = os.environ.get('ACCOUNT_EMAIL_VERIFICATION', 'mandatory')
+ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = True
+ACCOUNT_ADAPTER = 'users.adapters.AccountAdapter'
 
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
@@ -277,8 +280,31 @@ SOCIALACCOUNT_PROVIDERS = {
     }
 }
 
-# Email backend (console for development, override in production)
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# Email backend
+# Production: anymail.backends.brevo.EmailBackend (HTTP API via BREVO_API_KEY)
+# Development: django.core.mail.backends.console.EmailBackend
+EMAIL_BACKEND = os.environ.get(
+    'EMAIL_BACKEND',
+    'django.core.mail.backends.console.EmailBackend',
+)
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'Cannamente <noreply@cannamente.com>')
+SERVER_EMAIL = os.environ.get('SERVER_EMAIL', DEFAULT_FROM_EMAIL)
+
+ANYMAIL = {
+    'BREVO_API_KEY': os.environ.get('BREVO_API_KEY', ''),
+}
+
+# Celery
+CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'redis://redis:6379/0')
+CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', '')
+CELERY_TASK_ALWAYS_EAGER = os.environ.get('CELERY_TASK_ALWAYS_EAGER', 'False') == 'True'
+CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_TIMEZONE = 'UTC'
+CELERY_TASK_TIME_LIMIT = 60
+CELERY_TASK_SOFT_TIME_LIMIT = 45
 
 TINYMCE_DEFAULT_CONFIG = {
     "height": "320px",

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -26,6 +26,22 @@ services:
       timeout: 3s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: canna-redis-local
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - canna-network-local
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   web:
     build: .
     container_name: canna-web-local
@@ -38,11 +54,34 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - .env
     environment:
       USE_S3: ${USE_S3}
       POSTGRES_HOST: db
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
+    networks:
+      - canna-network-local
+
+  celery-worker:
+    build: .
+    container_name: canna-celery-worker-local
+    command: celery -A canna worker --loglevel=info --concurrency=${CELERY_WORKER_CONCURRENCY:-2}
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    environment:
+      USE_S3: ${USE_S3}
+      POSTGRES_HOST: db
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - canna-network-local
 
@@ -62,3 +101,4 @@ services:
 volumes:
   postgres_data:
   static_volume:
+  redis_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,21 @@ services:
       retries: 5
       start_period: 30s
 
+  redis:
+    image: redis:7-alpine
+    container_name: canna-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+    networks:
+      - canna-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
   web:
     build: .
     container_name: canna-web
@@ -41,6 +56,33 @@ services:
       POSTGRES_HOST: db
     depends_on:
       db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - canna-network
+
+  celery-worker:
+    build: .
+    container_name: canna-celery-worker
+    restart: unless-stopped
+    command: celery -A canna worker --loglevel=info --concurrency=${CELERY_WORKER_CONCURRENCY:-2}
+    volumes:
+      - .:/app
+      - ./logs:/app/logs
+    env_file:
+      - .env
+    environment:
+      USE_S3: ${USE_S3}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_STORAGE_BUCKET_NAME: ${AWS_STORAGE_BUCKET_NAME}
+      POSTGRES_HOST: db
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks:
       - canna-network
@@ -77,3 +119,4 @@ services:
 volumes:
   static_volume:
   postgres_data:
+  redis_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,6 @@ typing_extensions>=4.11
 urllib3==2.6.3
 django-allauth[socialaccount]==65.4.1
 sentry-sdk[django]==2.25.1
+celery[redis]==5.4.0
+redis==5.2.1
+django-anymail[brevo]==12.0

--- a/templates/account/confirm_email_verification_code.html
+++ b/templates/account/confirm_email_verification_code.html
@@ -1,0 +1,67 @@
+{% extends "base_auth.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Confirmar correo" %} — Cannamente{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/auth.css' %}" />
+{% endblock %}
+
+{% block content %}
+<section class="auth-page">
+  <div class="auth-card">
+    <a href="/" class="auth-card__close" aria-label="{% trans 'Cerrar' %}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+    </a>
+
+    <div class="auth-card__header">
+      <h1 class="auth-card__title">{% trans "Confirma tu correo" %}</h1>
+      <p class="auth-card__subtitle">
+        {% blocktranslate %}Hemos enviado un código a <strong>{{ email }}</strong>. Introdúcelo a continuación para activar tu cuenta.{% endblocktranslate %}
+      </p>
+    </div>
+
+    {% if form.non_field_errors %}
+    <div class="auth-errors">
+      <ul>
+        {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    {% url 'account_email_verification_sent' as action_url %}
+    <form method="post" action="{{ action_url }}" class="auth-form">
+      {% csrf_token %}
+
+      <div class="form-group">
+        <label for="{{ form.code.id_for_label }}">{% trans "Código de verificación" %}</label>
+        {{ form.code }}
+        {% if form.code.errors %}
+        <ul class="errorlist">
+          {% for error in form.code.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+
+      {{ redirect_field }}
+
+      <button type="submit" class="auth-btn auth-btn--primary">{% trans "Confirmar" %}</button>
+    </form>
+
+    <p class="auth-card__subtitle" style="margin-top:1rem">
+      {% trans "¿No recibiste el código? Revisa tu carpeta de spam o vuelve a intentarlo en unos minutos." %}
+    </p>
+
+    {% if not cancel_url %}
+    <form id="logout-from-stage" method="post" action="{% url 'account_logout' %}" style="margin-top:0.75rem">
+      <input type="hidden" name="next" value="{% url 'account_login' %}">
+      {% csrf_token %}
+      <button type="submit" class="auth-btn auth-btn--link">{% trans "Cancelar" %}</button>
+    </form>
+    {% else %}
+    <a href="{{ cancel_url }}" class="auth-btn auth-btn--link" style="margin-top:0.75rem;display:inline-block">{% trans "Cancelar" %}</a>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/account/email/email_confirmation_message.txt
+++ b/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,14 @@
+{% load account %}{% load i18n %}{% autoescape off %}{% user_display user as user_display %}{% blocktranslate %}Hola{% endblocktranslate %} {{ user_display }},
+
+{% if code %}{% blocktranslate %}Tu código de verificación de correo en Cannamente es:{% endblocktranslate %}
+
+    {{ code }}
+
+{% blocktranslate %}Introdúcelo en la ventana abierta del navegador para confirmar tu cuenta. El código caduca pronto, así que no tardes.{% endblocktranslate %}{% else %}{% blocktranslate %}Para confirmar tu cuenta en Cannamente, abre el siguiente enlace:{% endblocktranslate %}
+
+    {{ activate_url }}{% endif %}
+
+{% blocktranslate %}Si no creaste esta cuenta, puedes ignorar este mensaje.{% endblocktranslate %}
+
+— {% blocktranslate %}El equipo de Cannamente{% endblocktranslate %}
+{% endautoescape %}

--- a/templates/account/email/email_confirmation_signup_message.txt
+++ b/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.txt" %}

--- a/templates/account/email/email_confirmation_signup_subject.txt
+++ b/templates/account/email/email_confirmation_signup_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Bienvenido a Cannamente — confirma tu correo{% endblocktranslate %}

--- a/templates/account/email/email_confirmation_subject.txt
+++ b/templates/account/email/email_confirmation_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Confirma tu correo en Cannamente{% endblocktranslate %}

--- a/templates/account/email/password_reset_key_message.txt
+++ b/templates/account/email/password_reset_key_message.txt
@@ -1,0 +1,10 @@
+{% load account %}{% load i18n %}{% autoescape off %}{% user_display user as user_display %}{% blocktranslate %}Hola{% endblocktranslate %} {{ user_display }},
+
+{% blocktranslate %}Recibimos una solicitud para restablecer la contraseña de tu cuenta en Cannamente. Para crear una nueva contraseña, abre el siguiente enlace:{% endblocktranslate %}
+
+    {{ password_reset_url }}
+
+{% blocktranslate %}El enlace caduca pronto. Si no solicitaste este cambio, puedes ignorar este mensaje y tu contraseña no será modificada.{% endblocktranslate %}
+
+— {% blocktranslate %}El equipo de Cannamente{% endblocktranslate %}
+{% endautoescape %}

--- a/templates/account/email/password_reset_key_subject.txt
+++ b/templates/account/email/password_reset_key_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Restablece tu contraseña en Cannamente{% endblocktranslate %}

--- a/templates/account/verification_sent.html
+++ b/templates/account/verification_sent.html
@@ -23,7 +23,7 @@
         </svg>
       </div>
       <p class="auth-message__text">
-        {% trans "Te hemos enviado un correo de verificación. Por favor revisa tu bandeja de entrada y haz clic en el enlace para activar tu cuenta." %}
+        {% trans "Te hemos enviado un código de verificación a tu correo. Introdúcelo en la página anterior para activar tu cuenta." %}
       </p>
       <p class="auth-message__text">
         {% trans "Si no ves el correo, revisa tu carpeta de spam." %}

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -1,0 +1,24 @@
+from allauth.account.adapter import DefaultAccountAdapter
+
+from .tasks import send_email_task
+
+
+class AccountAdapter(DefaultAccountAdapter):
+    """Allauth adapter that dispatches email sending to a Celery worker."""
+
+    def send_mail(self, template_prefix, email, context):
+        message = self.render_mail(template_prefix, email, context)
+        html_body = None
+        for content, mimetype in getattr(message, 'alternatives', []):
+            if mimetype == 'text/html':
+                html_body = content
+                break
+
+        send_email_task.delay(
+            subject=message.subject,
+            body=message.body,
+            from_email=message.from_email,
+            recipients=list(message.to),
+            html_body=html_body,
+            headers=dict(message.extra_headers) if message.extra_headers else None,
+        )

--- a/users/migrations/0005_mark_existing_emails_verified.py
+++ b/users/migrations/0005_mark_existing_emails_verified.py
@@ -1,22 +1,25 @@
 from django.db import migrations
 
 
-def mark_existing_emails_verified(apps, schema_editor):
-    """Backfill allauth EmailAddress rows for users created before email verification was mandatory.
+def backfill_email_addresses(User, EmailAddress):
+    """Ensure every existing user has a verified EmailAddress matching User.email.
 
-    Without this, switching ACCOUNT_EMAIL_VERIFICATION to 'mandatory' would lock out every
-    existing user since allauth blocks login when no verified EmailAddress exists.
+    Without this, switching ACCOUNT_EMAIL_VERIFICATION to 'mandatory' would lock
+    out every existing user since allauth blocks login when no verified
+    EmailAddress exists.
+
+    Constraints we respect:
+    - allauth enforces a unique primary EmailAddress per user; we never set a
+      second `primary=True` and never flip an existing primary off.
+    - We do not modify the `primary` flag on rows that already exist; only the
+      `verified` flag, which is what unblocks login under mandatory verification.
     """
-    User = apps.get_model('users', 'CustomUser')
-    EmailAddress = apps.get_model('account', 'EmailAddress')
-
     for user in User.objects.exclude(email='').iterator():
         existing = EmailAddress.objects.filter(user=user, email__iexact=user.email).first()
         if existing:
-            if not existing.verified or not existing.primary:
+            if not existing.verified:
                 existing.verified = True
-                existing.primary = True
-                existing.save(update_fields=['verified', 'primary'])
+                existing.save(update_fields=['verified'])
             continue
 
         EmailAddress.objects.create(
@@ -25,6 +28,12 @@ def mark_existing_emails_verified(apps, schema_editor):
             verified=True,
             primary=not EmailAddress.objects.filter(user=user, primary=True).exists(),
         )
+
+
+def mark_existing_emails_verified(apps, schema_editor):
+    User = apps.get_model('users', 'CustomUser')
+    EmailAddress = apps.get_model('account', 'EmailAddress')
+    backfill_email_addresses(User, EmailAddress)
 
 
 def noop(apps, schema_editor):

--- a/users/migrations/0005_mark_existing_emails_verified.py
+++ b/users/migrations/0005_mark_existing_emails_verified.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+def mark_existing_emails_verified(apps, schema_editor):
+    """Backfill allauth EmailAddress rows for users created before email verification was mandatory.
+
+    Without this, switching ACCOUNT_EMAIL_VERIFICATION to 'mandatory' would lock out every
+    existing user since allauth blocks login when no verified EmailAddress exists.
+    """
+    User = apps.get_model('users', 'CustomUser')
+    EmailAddress = apps.get_model('account', 'EmailAddress')
+
+    for user in User.objects.exclude(email='').iterator():
+        existing = EmailAddress.objects.filter(user=user, email__iexact=user.email).first()
+        if existing:
+            if not existing.verified or not existing.primary:
+                existing.verified = True
+                existing.primary = True
+                existing.save(update_fields=['verified', 'primary'])
+            continue
+
+        EmailAddress.objects.create(
+            user=user,
+            email=user.email,
+            verified=True,
+            primary=not EmailAddress.objects.filter(user=user, primary=True).exists(),
+        )
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0004_customuser_display_name'),
+        ('account', '0009_emailaddress_unique_primary_email'),
+    ]
+
+    operations = [
+        migrations.RunPython(mark_existing_emails_verified, noop),
+    ]

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,0 +1,34 @@
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from django.core.mail import EmailMultiAlternatives
+
+
+logger = get_task_logger(__name__)
+
+
+@shared_task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    retry_jitter=True,
+    max_retries=5,
+)
+def send_email_task(self, subject, body, from_email, recipients, html_body=None, headers=None):
+    """Send a transactional email through the configured EMAIL_BACKEND.
+
+    Retries on any exception with exponential backoff.
+    """
+    message = EmailMultiAlternatives(
+        subject=subject,
+        body=body,
+        from_email=from_email,
+        to=recipients,
+        headers=headers or None,
+    )
+    if html_body:
+        message.attach_alternative(html_body, 'text/html')
+
+    sent = message.send()
+    logger.info('Email sent to %s (subject=%r, sent=%s)', recipients, subject, sent)
+    return sent

--- a/users/test_email_auth.py
+++ b/users/test_email_auth.py
@@ -1,0 +1,102 @@
+from unittest import mock
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+
+User = get_user_model()
+
+
+@override_settings(
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    ACCOUNT_EMAIL_VERIFICATION='mandatory',
+)
+class AccountAdapterTests(TestCase):
+    def test_send_mail_enqueues_celery_task(self):
+        from users.adapters import AccountAdapter
+
+        adapter = AccountAdapter()
+        with mock.patch('users.adapters.send_email_task.delay') as enqueue:
+            adapter.send_mail(
+                'account/email/email_confirmation',
+                'recipient@example.com',
+                {
+                    'user': User(email='recipient@example.com'),
+                    'activate_url': 'https://example.com/activate/abc',
+                    'current_site': mock.Mock(name='example', domain='example.com'),
+                    'key': 'abc',
+                },
+            )
+
+        self.assertEqual(enqueue.call_count, 1)
+        kwargs = enqueue.call_args.kwargs
+        self.assertEqual(kwargs['recipients'], ['recipient@example.com'])
+        self.assertIn('Cannamente', kwargs['subject'])
+        self.assertTrue(kwargs['body'])
+
+    def test_celery_task_actually_sends_email(self):
+        """In eager mode, calling send_mail should result in a real outgoing email."""
+        from users.adapters import AccountAdapter
+
+        adapter = AccountAdapter()
+        adapter.send_mail(
+            'account/email/email_confirmation',
+            'recipient@example.com',
+            {
+                'user': User(email='recipient@example.com'),
+                'activate_url': 'https://example.com/activate/abc',
+                'current_site': mock.Mock(name='example', domain='example.com'),
+                'key': 'abc',
+                'code': '123456',
+            },
+        )
+
+        self.assertEqual(len(mail.outbox), 1)
+        sent = mail.outbox[0]
+        self.assertEqual(sent.to, ['recipient@example.com'])
+        self.assertIn('123456', sent.body)
+
+
+@override_settings(
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    ACCOUNT_EMAIL_VERIFICATION='mandatory',
+)
+class SignupVerificationFlowTests(TestCase):
+    def test_signup_creates_unverified_email_and_sends_confirmation(self):
+        client = Client()
+        response = client.post(
+            reverse('account_signup'),
+            data={
+                'email': 'newuser@example.com',
+                'password1': 'StrongPass!2345',
+                'password2': 'StrongPass!2345',
+            },
+        )
+
+        self.assertIn(response.status_code, (200, 302))
+        user = User.objects.get(email='newuser@example.com')
+        email_address = EmailAddress.objects.get(user=user, email__iexact='newuser@example.com')
+        self.assertFalse(email_address.verified)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['newuser@example.com'])
+
+    def test_password_reset_sends_email_for_existing_user(self):
+        user = User.objects.create_user(email='member@example.com', password='OldPass!1234')
+        EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
+
+        client = Client()
+        response = client.post(
+            reverse('account_reset_password'),
+            data={'email': 'member@example.com'},
+        )
+
+        self.assertIn(response.status_code, (200, 302))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('member@example.com', mail.outbox[0].to)

--- a/users/test_email_auth.py
+++ b/users/test_email_auth.py
@@ -87,6 +87,37 @@ class SignupVerificationFlowTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ['newuser@example.com'])
 
+    def test_signup_then_confirm_with_code_logs_user_in(self):
+        """Full flow: signup → grab code from session → submit → email verified."""
+        client = Client()
+        client.post(
+            reverse('account_signup'),
+            data={
+                'email': 'flow@example.com',
+                'password1': 'StrongPass!2345',
+                'password2': 'StrongPass!2345',
+            },
+        )
+
+        verification = client.session.get('account_email_verification_code')
+        self.assertIsNotNone(verification, 'allauth should have stashed a code in session')
+        code = verification['code']
+        self.assertEqual(len(code), 6)
+
+        confirm_response = client.post(
+            reverse('account_email_verification_sent'),
+            data={'code': code},
+            follow=True,
+        )
+
+        self.assertEqual(confirm_response.status_code, 200)
+        email_address = EmailAddress.objects.get(email__iexact='flow@example.com')
+        self.assertTrue(email_address.verified)
+        self.assertTrue(
+            client.session.get('_auth_user_id'),
+            'user should be logged in after successful code confirmation',
+        )
+
     def test_password_reset_sends_email_for_existing_user(self):
         user = User.objects.create_user(email='member@example.com', password='OldPass!1234')
         EmailAddress.objects.create(user=user, email=user.email, verified=True, primary=True)
@@ -100,3 +131,64 @@ class SignupVerificationFlowTests(TestCase):
         self.assertIn(response.status_code, (200, 302))
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('member@example.com', mail.outbox[0].to)
+
+
+class BackfillMigrationTests(TestCase):
+    """Direct exercise of the migration's backfill helper.
+
+    pytest.ini sets --nomigrations so the migration itself does not run during
+    tests; we test the helper against the live models, which share the same
+    invariants as the historical models the migration uses.
+    """
+
+    def _backfill(self):
+        import importlib
+
+        mod = importlib.import_module(
+            'users.migrations.0005_mark_existing_emails_verified',
+        )
+        mod.backfill_email_addresses(User, EmailAddress)
+
+    def test_user_with_no_email_address_gets_one_created(self):
+        user = User.objects.create_user(email='fresh@example.com', password='Pass!12345')
+        EmailAddress.objects.filter(user=user).delete()
+
+        self._backfill()
+
+        ea = EmailAddress.objects.get(user=user, email__iexact='fresh@example.com')
+        self.assertTrue(ea.verified)
+        self.assertTrue(ea.primary)
+
+    def test_existing_unverified_row_gets_verified_without_touching_primary(self):
+        user = User.objects.create_user(email='dup@example.com', password='Pass!12345')
+        EmailAddress.objects.filter(user=user).delete()
+        # Pre-existing scenario: another email is already primary, ours is not.
+        other_primary = EmailAddress.objects.create(
+            user=user, email='other@example.com', verified=False, primary=True,
+        )
+        ours = EmailAddress.objects.create(
+            user=user, email='dup@example.com', verified=False, primary=False,
+        )
+
+        self._backfill()
+
+        ours.refresh_from_db()
+        other_primary.refresh_from_db()
+        self.assertTrue(ours.verified, 'matching row must end up verified')
+        self.assertFalse(ours.primary, 'must not flip primary on existing row')
+        self.assertTrue(other_primary.primary, 'must not unset existing primary')
+
+    def test_user_with_existing_primary_unrelated_email_does_not_violate_unique(self):
+        """The risky case: row matching User.email is missing, but another primary exists."""
+        user = User.objects.create_user(email='solo@example.com', password='Pass!12345')
+        EmailAddress.objects.filter(user=user).delete()
+        EmailAddress.objects.create(
+            user=user, email='legacy@example.com', verified=True, primary=True,
+        )
+
+        self._backfill()
+
+        new_row = EmailAddress.objects.get(user=user, email__iexact='solo@example.com')
+        self.assertTrue(new_row.verified)
+        self.assertFalse(new_row.primary, 'new row must not duplicate existing primary')
+        self.assertEqual(EmailAddress.objects.filter(user=user, primary=True).count(), 1)


### PR DESCRIPTION
Wires transactional email through django-anymail (Brevo HTTP API), backed by a dedicated Celery worker container so signup/password-reset are not blocked by SMTP latency. Switches allauth to mandatory email verification using a 6-digit code instead of activation links.

- Adds celery[redis], redis, django-anymail[brevo] dependencies
- Adds canna/celery.py app and exports canna.celery_app
- AccountAdapter renders mail then dispatches to send_email_task with retries
- Mandatory verification + ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED=True
- Branded bilingual templates (ES source) for confirmation, code page, reset
- Data migration backfills EmailAddress(verified=True) for existing users
- Adds redis + celery-worker services to both compose files
- Tests cover adapter dispatch, task execution, signup and reset flows